### PR TITLE
patch fix for validating dataset_jpath specifications

### DIFF
--- a/schemas/hysds-io-schema.json
+++ b/schemas/hysds-io-schema.json
@@ -14,7 +14,7 @@
         "from": {
           "description": "value for hard-coded parameter value, submitter for user submitted value, dataset_jpath:<jpath> to extract value from ElasticSearch result using a JPath-like notation",
           "type": "string",
-          "pattern": "(passthrough|value|submitter|dataset_jpath\\:.+)"
+          "pattern": "(passthrough|value|submitter|dataset_jpath\\:.*)"
         },
         "value": {
           "description": "hard-coded parameter value",

--- a/test/schemas/test-files/hysds-io.json.valid
+++ b/test/schemas/test-files/hysds-io.json.valid
@@ -10,6 +10,12 @@
       "lambda": "lambda ds: \"%s/%s\" % ((filter(lambda x: x.startswith('s3://'), ds['urls']) or ds['urls'])[0], ds['metadata']['data_product_name'])"
     },
     {
+      "name":"localize_products",
+      "from":"dataset_jpath:",
+      "type":"text",
+      "lambda" : "lambda met: get_partial_products(met['_id'], get_best_url(met['_source']['urls']), [ met['_id']+'.met.json', met['_id']+'.nc' ])"
+    },
+    {
       "name": "test_dataset_jpath",
       "from": "dataset_jpath:_source.metadata.data_product_name"
     },


### PR DESCRIPTION
This patch fix provides support for being able to allow the use of `dataset_jpath:` in the HySDS IO.