### PR TITLE
Hc 163 container builder (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,160 @@
 *.pyc
 build
 *.egg-info
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+.idea
+.idea/
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/config/es_template.json
+++ b/config/es_template.json
@@ -1,52 +1,55 @@
 {
-  "order" : 0,
-  "template" : "{{ index }}",
-  "settings" : {
-    "index.refresh_interval" : "5s",
+  "order": 0,
+  "template": "{{ index }}",
+  "settings": {
+    "index.refresh_interval": "5s",
     "analysis": {
       "analyzer": {
         "default": {
           "filter": [
-            "standard", 
-            "lowercase", 
+            "lowercase",
             "word_delimiter"
-          ], 
+          ],
           "tokenizer": "keyword"
         }
       }
     }
   },
-  "mappings" : {
-    "_default_" : {
-      "dynamic_templates" : [ {
-        "string_fields" : {
-          "mapping" : {
-            "index" : "analyzed",
-            "omit_norms" : true,
-            "type" : "string",
-            "fields" : {
-              "raw" : {
-                "index" : "not_analyzed",
-                "ignore_above" : 256,
-                "type" : "string"
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "integers": {
+          "match_mapping_type": "long",
+          "mapping": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "norms": false,
+            "type": "text",
+            "copy_to": "text_fields",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
               }
             }
           },
-          "match_mapping_type" : "string",
-          "match" : "*"
+          "match": "*"
         }
-      } ],
-      "_id": {
-        "type": "string",
-        "store": true,
-        "index": "not_analyzed"
-      },
+      }
+    ],
+    "properties": {
       "_timestamp": {
-        "enabled": true,
+        "type": "date",
         "store": true
       },
-      "_all" : {
-        "enabled" : true
+      "text_fields": {
+        "type": "text"
       }
     }
   }

--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-__version__ = "0.2.4"
+
+__version__ = "0.3.0"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/action_utils.py
+++ b/hysds_commons/action_utils.py
@@ -106,3 +106,17 @@ def get_action_spec(iospec_es_url, jobspec_es_url, ops_account="ops"):
             jobspec_es_url, wiring, ops_account))
     #logger.info("action_specs: %s" % json.dumps(action_specs, indent=2))
     return action_specs
+
+
+def check_passthrough_query(params):
+    """
+    returns True if params is:
+    {
+        "from": "passthrough",
+        "name": "query"
+    }
+    """
+    for param in params:
+        if param['from'] == 'passthrough' and param['name'] == 'query':
+            return True
+    return False

--- a/hysds_commons/container_utils.py
+++ b/hysds_commons/container_utils.py
@@ -8,7 +8,6 @@ import hysds_commons.metadata_rest_utils
 
 
 CONTAINER_INDEX = "containers"
-CONTAINER_TYPE = "container"
 
 
 def get_container_types(es_url, logger=None):
@@ -17,8 +16,7 @@ def get_container_types(es_url, logger=None):
     @param es_url - elasticsearch URL
     @return: list of container ids
     '''
-    return hysds_commons.metadata_rest_utils.get_types(es_url, CONTAINER_INDEX,
-                                                       logger=logger)
+    return hysds_commons.metadata_rest_utils.get_types(es_url, CONTAINER_INDEX, logger=logger)
 
 
 def get_container(es_url, ident, logger=None):
@@ -26,11 +24,10 @@ def get_container(es_url, ident, logger=None):
     Get a container (JSON body)
     @param es_url - elasticsearch URL
     @param ident - identity of container
+    @param container_type - mapping type for container index, only _doc type allowed in es7
     @return: dict representing anonymous object of HySDS IO
     '''
-    return hysds_commons.metadata_rest_utils.get_by_id(es_url, CONTAINER_INDEX,
-                                                       CONTAINER_TYPE, ident,
-                                                       logger=logger)
+    return hysds_commons.metadata_rest_utils.get_by_id(es_url, CONTAINER_INDEX, ident, logger=logger)
 
 
 def add_container(es_url, name, url, version, digest, logger=None):
@@ -40,15 +37,16 @@ def add_container(es_url, name, url, version, digest, logger=None):
     @param name - name of object for ingestion into ES
     @param url - url of object for ingestion into ES
     @param version - version of object for ingestion into ES
+    @param container_type - mapping type for container index, only _doc type allowed in es7
     @param digest - sha256 digest ID of container image
     '''
-    return hysds_commons.metadata_rest_utils.add_metadata(es_url, CONTAINER_INDEX,
-                                                          CONTAINER_TYPE, {
-                                                              "id": name,
-                                                              "digest": digest,
-                                                              "url": url,
-                                                              "version": version},
-                                                          logger=logger)
+    container_obj = {
+        "id": name,
+        "digest": digest,
+        "url": url,
+        "version": version
+    }
+    return hysds_commons.metadata_rest_utils.add_metadata(es_url, CONTAINER_INDEX, container_obj, logger=logger)
 
 
 def remove_container(es_url, ident, logger=None):
@@ -56,7 +54,6 @@ def remove_container(es_url, ident, logger=None):
     Remove a container
     @param es_url - elasticsearch URL
     @param ident - id to delete
+    @param container_type - mapping type for container index, only _doc type allowed in es7
     '''
-    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, CONTAINER_INDEX,
-                                                             CONTAINER_TYPE, ident,
-                                                             logger=logger)
+    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, CONTAINER_INDEX, ident, logger=logger)

--- a/hysds_commons/elasticsearch_connection.py
+++ b/hysds_commons/elasticsearch_connection.py
@@ -1,0 +1,26 @@
+#!/bin/env python
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+
+from hysds.celery import app
+from hysds.log_utils import logger
+from .elasticsearch_utils import ElasticsearchUtility
+
+
+"""
+because of cyclical dependency issues, i cannot initialize mozart_es and grq_es in "hysds" core repo
+hysds_commons is already importing hysds.celery
+
+so i am initializing it here to avoid the ImportError
+
+raised unexpected: ImportError("cannot import name 'mozart_es' from 'hysds':
+(/export/home/hysdsops/verdi/ops/hysds/hysds/__init__.py)")
+"""
+
+mozart_es = ElasticsearchUtility(app.conf['JOBS_ES_URL'], logger)
+grq_es = ElasticsearchUtility(app.conf['GRQ_ES_URL'], logger)

--- a/hysds_commons/hysds_io_utils.py
+++ b/hysds_commons/hysds_io_utils.py
@@ -8,7 +8,6 @@ import hysds_commons.metadata_rest_utils
 
 
 HYSDS_IO_INDEX = "hysds_ios"
-HYSDS_IO_TYPE = "hysds_io"
 
 
 def get_hysds_io_types(es_url, logger=None):
@@ -24,9 +23,10 @@ def get_hysds_ios(es_url, logger=None):
     '''
     Get all hysds_io docs from ES
     @param es_url - elastic search URL (from owning app i.e. Mozart, Tosca)
+    @param hysds_io_type - str - ES type in the hysds_ios index (optional for now because types are removed in es7+)
     @return: dict representing anonymous object of HySDS IO
     '''
-    return hysds_commons.metadata_rest_utils.get_all(es_url, HYSDS_IO_INDEX, HYSDS_IO_TYPE, logger=logger)
+    return hysds_commons.metadata_rest_utils.get_all(es_url, HYSDS_IO_INDEX, logger=logger)
 
 
 def get_hysds_io(es_url, ident, logger=None):
@@ -34,9 +34,10 @@ def get_hysds_io(es_url, ident, logger=None):
     Get a hysds_io (JSON body)
     @param es_url - elastic search URL (from owning app i.e. Mozart, Tosca)
     @param ident - identity of hysds_io
+    @param hysds_io_type - str - ES type in the hysds_ios index (optional for now because types are removed in es7+)
     @return: dict representing anonymous object of HySDS IO
     '''
-    return hysds_commons.metadata_rest_utils.get_by_id(es_url, HYSDS_IO_INDEX, HYSDS_IO_TYPE, ident, logger=logger)
+    return hysds_commons.metadata_rest_utils.get_by_id(es_url, HYSDS_IO_INDEX, ident, logger=logger)
 
 
 def add_hysds_io(es_url, obj, logger=None):
@@ -44,8 +45,9 @@ def add_hysds_io(es_url, obj, logger=None):
     Ingests a hysds_io into the Mozart ElasticSearch index
     @param es_url - elastic search URL (from owning app i.e. Mozart, Tosca)
     @param obj - object for ingestion into ES
+    @param hysds_io_type - str - ES type in the hysds_ios index (optional for now because types are removed in es7+)
     '''
-    return hysds_commons.metadata_rest_utils.add_metadata(es_url, HYSDS_IO_INDEX, HYSDS_IO_TYPE, obj, logger=logger)
+    return hysds_commons.metadata_rest_utils.add_metadata(es_url, HYSDS_IO_INDEX, obj, logger=logger)
 
 
 def remove_hysds_io(es_url, ident, logger=None):
@@ -54,4 +56,4 @@ def remove_hysds_io(es_url, ident, logger=None):
     @param es_url - elastic search URL (from owning app i.e. Mozart, Tosca)
     @param ident - id to delete
     '''
-    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, HYSDS_IO_INDEX, HYSDS_IO_TYPE, ident, logger=logger)
+    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, HYSDS_IO_INDEX, ident, logger=logger)

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -6,111 +6,87 @@ from __future__ import absolute_import
 from builtins import str
 from future import standard_library
 standard_library.install_aliases()
-import copy
+
 import json
 import traceback
 import logging
 
-from hysds_commons.request_utils import post_scrolled_json_responses
-from hysds_commons.hysds_io_utils import get_hysds_io
-from hysds_commons.job_utils import submit_mozart_job
-
 from hysds.celery import app
+from .elasticsearch_connection import mozart_es, grq_es
 
+from hysds_commons.job_utils import submit_mozart_job
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("job-iterator")
 
+HYSDS_IOS_GRQ = app.conf.get('HYSDS_IOS_GRQ', 'hysds_ios-grq')
+HYSDS_IOS_MOZART = app.conf.get('HYSDS_IOS_MOZART', 'hysds_ios-mozart')
+
 
 def get_component_config(component):
-    '''
+    """
     From a component get the common configuration values
     @param component - component 
-    '''
+    """
     if component == "mozart" or component == "figaro":
-        es_url = app.conf["JOBS_ES_URL"]
         query_idx = app.conf["STATUS_ALIAS"]
         facetview_url = app.conf["MOZART_URL"]
-    elif component == "tosca":
-        es_url = app.conf["GRQ_ES_URL"]
+    else:  # tosca:
         query_idx = app.conf["DATASET_ALIAS"]
         facetview_url = app.conf["GRQ_URL"]
-    return (es_url, query_idx, facetview_url)
-
-
-def normalize_query(rule):
-    """Normalize final query."""
-
-    if rule.get('passthru_query', False) is True:
-        query = rule['query']
-        filts = []
-        if 'filtered' in query:
-            final_query = copy.deepcopy(query)
-            filts.append(final_query['filtered']['filter'])
-            final_query['filtered']['filter'] = {
-                'and': filts
-            }
-        else:
-            final_query = {
-                'filtered': {
-                    'query': query
-                }
-            }
-        final_query = {"query": final_query}
-        logger.info("final_query: %s" % json.dumps(final_query, indent=2))
-        rule['query'] = final_query
-        rule['query_string'] = json.dumps(final_query)
+    return query_idx, facetview_url
 
 
 def iterate(component, rule):
-    '''
+    """
     Iterator used to iterate across a query result and submit jobs for every hit
     @param component - "mozart" or "tosca" where this submission came from
     @param rule - rule containing information for running jobs
-    '''
-    # Accumulators variables
-    ids = []
+    """
+    ids = []  # Accumulators variables
     error_count = 0
     errors = []
 
-    # Read config from "origin"
-    es_url, es_index, ignore1 = get_component_config(component)
+    es_index, ignore1 = get_component_config(component)  # Read config from "origin"
 
     # Read in JSON formatted args and setup passthrough
-    normalize_query(rule)
     if 'query' in rule.get('query', {}):
         queryobj = rule["query"]
     else:
-        queryobj = {"query": rule["query"]}
+        queryobj = {
+            "query": rule["query"]
+        }
+        rule['query'] = {
+            "query": rule['query']
+        }
+    logger.info("Elasticsearch queryobj: %s" % json.dumps(queryobj))
 
-    # Get wiring
-    hysdsio = get_hysds_io(es_url, rule["job_type"], logger=logger)
+    # Get hysds_ios wiring
+    hysds_io_index = HYSDS_IOS_MOZART if component in ('mozart', 'figaro') else HYSDS_IOS_GRQ
+    hysdsio = mozart_es.get_by_id(hysds_io_index, rule["job_type"], _source=False)
 
     # Is this a single submission
     passthru = rule.get('passthru_query', False)
-    single = hysdsio.get(
-        "submission_type", "individual" if passthru is True else "iteration") == "individual"
+    single = hysdsio.get("submission_type", "individual" if passthru is True else "iteration") == "individual"
     logger.info("single submission type: %s" % single)
 
     # Do we need the results
     run_query = False if single else True
     if not run_query:  # check if we need the results anyway
-        run_query = any((i["from"].startswith('dataset_jpath')
-                         for i in hysdsio["params"]))
+        run_query = any((i["from"].startswith('dataset_jpath') for i in hysdsio["params"]))
     logger.info("run_query: %s" % run_query)
 
     # Run the query to get the products; for efficiency, run query only if we need the results
     results = [{"_id": "Transient Faux-Results"}]
     if run_query:
-        # Scroll product results
-        start_url = "{0}/{1}/_search".format(es_url, es_index)
-        scroll_url = "{0}/_search".format(es_url, es_index)
-        results = post_scrolled_json_responses(start_url, scroll_url, data=json.dumps(queryobj),
-                                               logger=logger, generator=True)
+        if component == "mozart" or component == "figaro":
+            results = mozart_es.query(es_index, queryobj)
+        else:
+            results = grq_es.query(es_index, queryobj)
 
     # What to iterate for submission
-    submission_iterable = [
-        {"_id": "Global Single Submission"}] if single else results
+    submission_iterable = [{"_id": "Global Single Submission"}] if single else results
+
     # Iterator loop
     for item in submission_iterable:
         try:
@@ -134,19 +110,18 @@ def iterate(component, rule):
             # override enable_dedup setting from hysdsio
             if 'enable_dedup' in hysdsio:
                 enable_dedup = hysdsio['enable_dedup']
-                logger.info("hysdsio overrided enable_dedup: %s" %
-                            enable_dedup)
+                logger.info("hysdsio overrided enable_dedup: %s" % enable_dedup)
 
-            ids.append(submit_mozart_job(product, rule, hysdsio,
-                                         job_name=job_name,
-                                         enable_dedup=enable_dedup))
+            task_id = submit_mozart_job(product, rule, hysdsio, job_name=job_name, enable_dedup=enable_dedup)
+            ids.append(task_id)
+
         except Exception as e:
             error_count = error_count + 1
             if not str(e) in errors:
                 errors.append(str(e))
-            logger.warning(
-                "Failed to submit jobs: {0}:{1}".format(type(e), str(e)))
+            logger.warning("Failed to submit jobs: {0}:{1}".format(type(e), str(e)))
             logger.warning(traceback.format_exc())
+
     if error_count > 0:
         logger.error("Failed to submit: {0} of {1} jobs. {2}".format(
             error_count, len(list(results)), " ".join(errors)))

--- a/hysds_commons/job_rest_utils.py
+++ b/hysds_commons/job_rest_utils.py
@@ -4,28 +4,26 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-import json
-import traceback
 
+import json
 from hysds_commons.job_utils import resolve_mozart_job
 from hysds_commons.mozart_utils import submit_job
 from hysds_commons.log_utils import logger
 
 
-def single_process_and_submission(mozart_url, product, rule, hysdsio=None,
-                                  es_hysdsio_url=None, queue=None):
-    '''
+def single_process_and_submission(mozart_url, product, rule, hysdsio=None, queue=None, component=None):
+    """
     Run a single job from inside the iterator
     @param mozart_url - mozart url to submit to
     @param product - product result body
     @param rule - rule specification body
     @param hysdsio - (optional) hysds-io body
-    @param es_hysdsio_url - (optional) url to request hysdsio data from
+    @param component - (optional) tosca/grq or mozart/figaro, get hysds_io from ES (hysds_ios-mozart vs hysds_ios-grq)
     @param queue - (optional) job queue override
-    '''
+    """
 
     # resolve job
-    job = resolve_mozart_job(product, rule, hysdsio, es_hysdsio_url, queue)
+    job = resolve_mozart_job(product, rule, hysdsio, queue, component)
     logger.info("resolved job: {}".format(json.dumps(job, indent=2)))
 
     # submit job

--- a/hysds_commons/job_spec_utils.py
+++ b/hysds_commons/job_spec_utils.py
@@ -8,7 +8,6 @@ import hysds_commons.metadata_rest_utils
 
 
 JOB_SPEC_INDEX = "job_specs"
-JOB_SPEC_TYPE = "job_spec"
 
 
 def get_job_spec_types(es_url, logger=None):
@@ -24,9 +23,10 @@ def get_job_specs(es_url, logger=None):
     '''
     Get all job spec docs from ES
     @param es_url - elastic search URL
+    @param job_spec_type - es index type, now _doc type in es7+, preserve for now
     @return: dict representing anonymous object of job specs
     '''
-    return hysds_commons.metadata_rest_utils.get_all(es_url, JOB_SPEC_INDEX, JOB_SPEC_TYPE, logger=logger)
+    return hysds_commons.metadata_rest_utils.get_all(es_url, JOB_SPEC_INDEX, logger=logger)
 
 
 def get_job_spec(es_url, ident, logger=None):
@@ -34,24 +34,27 @@ def get_job_spec(es_url, ident, logger=None):
     Get a job_spec (JSON body)
     @param es_url - elasticsearch URL
     @param ident - identity of job_spec
+    @param job_spec_type - es index type, now _doc type in es7+, preserve for now
     @return: dict representing anonymous object of HySDS IO
     '''
-    return hysds_commons.metadata_rest_utils.get_by_id(es_url, JOB_SPEC_INDEX, JOB_SPEC_TYPE, ident, logger=logger)
+    return hysds_commons.metadata_rest_utils.get_by_id(es_url, JOB_SPEC_INDEX, ident, logger=logger)
 
 
 def add_job_spec(es_url, obj, logger=None):
     '''
     Ingests a job_spec into ES
     @param es_url - elasticsearch URL
+    @param job_spec_type - es index type, now _doc type in es7+, preserve for now
     @param obj - object for ingestion into ES
     '''
-    return hysds_commons.metadata_rest_utils.add_metadata(es_url, JOB_SPEC_INDEX, JOB_SPEC_TYPE, obj, logger=logger)
+    return hysds_commons.metadata_rest_utils.add_metadata(es_url, JOB_SPEC_INDEX, obj, logger=logger)
 
 
 def remove_job_spec(es_url, ident, logger=None):
     '''
     Remove a container
     @param es_url - elasticsearch URL
+    @param job_spec_type - es index type, now _doc type in es7+, preserve for now
     @param ident - id to delete
     '''
-    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, JOB_SPEC_INDEX, JOB_SPEC_TYPE, ident, logger=logger)
+    return hysds_commons.metadata_rest_utils.remove_metadata(es_url, JOB_SPEC_INDEX, ident, logger=logger)

--- a/hysds_commons/metadata_rest_utils.py
+++ b/hysds_commons/metadata_rest_utils.py
@@ -4,87 +4,127 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-import requests
+
 import json
-from . import request_utils
+from hysds_commons.elasticsearch_utils import get_es_scrolled_data
+from elasticsearch import Elasticsearch, NotFoundError, ElasticsearchException
 
 
 def get_types(es_url, es_index, logger=None):
-    '''
+    """
     Get the listing of spec IDs from an ES index
     @param es_url: elastic search url
     @param es_index: index to list from
     @return: list of ids from given index
-    '''
+    """
 
-    query = {"query": {"match_all": {}}}
-    url = "{0}/{1}/_search".format(es_url, es_index)
-    es_url = "{0}/_search".format(es_url)
-    data = json.dumps(query)
-    results = request_utils.post_scrolled_json_responses(
-        url, es_url, data=data, logger=logger)
+    query = {
+        "query": {
+            "match_all": {}
+        }
+    }
+    results = get_es_scrolled_data(es_url, es_index, query)
+    logger.info("Received all _id's from index: %s" % es_index)
     return sorted([result["_id"] for result in results])
 
 
-def get_all(es_url, es_index, es_type, query=None, logger=None):
-    '''
+def get_all(es_url, es_index, query=None, logger=None):
+    """
     Get all spec documents in ES index
     @param es_url: elastic search url
     @param es_index - index containing id
-    @param es_type - index containing type
     @return: list of all specification docs
-    '''
+    """
 
     if query is None:
-        query = {"query": {"match_all": {}}}
-    url = "{0}/{1}/_search".format(es_url, es_index)
-    es_url = "{0}/_search".format(es_url)
-    return request_utils.post_scrolled_json_responses(url, es_url, data=json.dumps(query), logger=logger)
+        query = {
+            "query": {
+                "match_all": {}
+            }
+        }
+    results = get_es_scrolled_data(es_url, es_index, query)
+    logger.info("get_all query: %s" % json.dumps(query, indent=2))
+    logger.info("retrieved all data from index: %s" % es_index)
+    return results
 
 
-def get_by_id(es_url, es_index, es_type, ident, logger=None):
-    '''
+def get_by_id(es_url, es_index, ident, safe=False, logger=None):
+    """
     Get a spec document by ID
     @param es_url: elastic search url
     @param es_index - index containing id
-    @param es_type - index containing type
     @param ident - ID
+    @param safe - returns False if set to True, raises Exception if set to False
     @return: dict representing anonymous object of specifications
-    '''
+    """
 
     if ident is None:
         raise Exception("id must be supplied")
-    final_url = '{0}/{1}/{2}/{3}'.format(es_url, es_index, es_type, ident)
-    dataset_metadata = request_utils.get_requests_json_response(
-        final_url, logger=logger)
+
+    es = Elasticsearch([es_url])
+    try:
+        dataset_metadata = es.get(index=es_index, id=ident)
+    except NotFoundError as e:
+        if safe:
+            logger.warning("%s not found in index %s" % (ident, es_index))
+            logger.warning(e)
+            return False
+        else:
+            logger.error("%s not found in index %s" % (ident, es_index))
+            logger.error(e)
+            raise Exception("%s not found in index %s" % (ident, es_index))
+    except ElasticsearchException as e:
+        if logger:
+            logger.error(e)
+        raise Exception(e)
+
     # Navigate around Dataset metadata to get true specification
     ret = dataset_metadata["_source"]
     return ret
 
 
-def add_metadata(es_url, es_index, es_type, obj, logger=None):
-    '''
+def add_metadata(es_url, es_index, obj, logger=None):
+    """
     Ingests a metadata into the Mozart ElasticSearch index
     @param es_url: elastic search url
     @param es_index - ElasticSearch index to place object into
-    @param es_type - ElasticSearch type to place object into
     @param obj - object for ingestion into ES
-    '''
+    """
+    es = Elasticsearch([es_url])
+    id = obj['id']
+    try:
+        es.index(index=es_index, id=id, body=obj)
+        logger.info("added to index %s: %s" % (es_index, id))
+    except ElasticsearchException as e:
+        logger.error("unable to index document: %s" % id)
+        logger.error(e)
+        raise Exception(e)
 
-    #data = {"doc_as_upsert": True,"doc":obj}
-    final_url = "{0}/{1}/{2}/{3}".format(es_url, es_index, es_type, obj["id"])
-    request_utils.requests_json_response(
-        "POST", final_url, json.dumps(obj), logger=logger)
 
-
-def remove_metadata(es_url, es_index, es_type, ident, logger=None):
-    '''
+def remove_metadata(es_url, es_index, ident, safe=False, logger=None):
+    """
     Remove a container
     @param es_url: elastic search url
     @param es_index - ElasticSearch index to place object into
-    @param es_type - ElasticSearch type to place object into
     @param ident - id of container to delete
-    '''
+    """
+    if ident is None:
+        raise Exception("id must be supplied")
 
-    final_url = "{0}/{1}/{2}/{3}".format(es_url, es_index, es_type, ident)
-    request_utils.requests_json_response("DELETE", final_url, logger=logger)
+    es = Elasticsearch([es_url])
+    try:
+        es.delete(index=es_index, id=ident)
+        logger.info("%s deleted from index: %s" % (ident, es_index))
+    except NotFoundError as e:
+        if safe:
+            logger.warning("%s not found in index %s" % (ident, es_index))
+            logger.warning(e)
+            return False
+        else:
+            logger.error("%s not found in index %s" % (ident, es_index))
+            logger.error(e)
+            raise Exception("%s not found in index %s" % (ident, es_index))
+    except ElasticsearchException as e:
+        if logger:
+            logger.error(e)
+        raise Exception(e)

--- a/hysds_commons/queue_utils.py
+++ b/hysds_commons/queue_utils.py
@@ -26,12 +26,12 @@ HYSDS_QUEUES = (
 
 
 def get_all_queues(rabbitmq_admin_url):
-    '''
+    """
     List the queues available for job-running
     Note: does not return celery internal queues
     @param rabbitmq_admin_url: RabbitMQ admin URL
     @return: list of queues
-    '''
+    """
 
     try:
         data = get_requests_json_response(

--- a/hysds_commons/request_utils.py
+++ b/hysds_commons/request_utils.py
@@ -10,20 +10,26 @@ import requests
 import json
 
 
-def requests_json_response(method, url, data="{}", ignore_errors=False, auth=None, verify=True, logger=None):
+def requests_json_response(method, url, data="{}", ignore_errors=False, auth=None, verify=True, logger=None,
+                           attached_headers=None):
     '''
     Sends a request with supplied data and method
     @param method - "GET" or "POST" method
     @param url - url to request
     @param data - data to send along with request
+    @param attached_headers - optional headers if you want to pass through
     @return: dictionary representing JSON object
     '''
 
+    # headers = {"Content-Type": "application/json"}
     try:
         if method == "GET":
             r = requests.get(url, data=data, auth=auth, verify=verify)
         elif method == "POST":
-            r = requests.post(url, data=data, auth=auth, verify=verify)
+            if attached_headers:
+                r = requests.post(url, data=data, auth=auth, verify=verify, headers=attached_headers)
+            else:
+                r = requests.post(url, data=data, auth=auth, verify=verify)
         elif method == "DELETE":
             r = requests.delete(url, auth=auth, verify=verify)
         else:
@@ -79,7 +85,7 @@ def post_scrolled_json_responses(url, es_url, generator=False, **kwargs):
         if not url.rstrip("/").endswith("_search"):
             raise Exception(
                 "Scrolling only works on search URLs. {0} incompatible.".format(url))
-        setup_url = url + "?search_type=scan&scroll=10m&size=100"
+        setup_url = url + "?scroll=10m&size=100"  # search_type=scan& removed in ES 7.1
         result = post_requests_json_response(setup_url, **kwargs)
         # Harvest scan-setup
         count = result['hits']['total']

--- a/scripts/install_es_template.py
+++ b/scripts/install_es_template.py
@@ -21,8 +21,9 @@ def write_template(es_url, index, tmpl_file):
     with open(tmpl_file) as f:
         tmpl = Template(f.read()).render(index=index)
     tmpl_url = "%s/_template/%s" % (es_url, index)
-    r = requests.delete(tmpl_url)
-    r = requests.put(tmpl_url, data=tmpl)
+    headers = {'Content-Type': 'application/json'}
+    r = requests.delete(tmpl_url, headers=headers)
+    r = requests.put(tmpl_url, data=tmpl, headers=headers)
     r.raise_for_status()
     print(r.json())
     print("Successfully installed template %s at %s." % (index, tmpl_url))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'requests>=2.7.0', 'future>=0.17.1', "jsonschema>=3.0.1"
+        'requests>=2.7.0',
+        'future>=0.17.1',
+        "jsonschema>=3.0.1"
     ]
 )


### PR DESCRIPTION
* Hc 123 container builder (#9)

* added optional argument hysds_io_type to keep functionality of mozart ES for now without compromising the changes in GRQ

mapping type removed in es7, is defaulted to _doc now
added gitignore stuff

* hysds_commons.container_utils to take optional container_type (index type) argument

index types defualt to _doc now
some formatting stuff

* edited config/es_template.json for es7 compatible mapping

added optional job_spec_type argument in job_spec_utils.py in case we upgrade to es7

* added mapping template for es7 and header for install_es_template.py

* added es_template_es1.json

* added headers in requests_utils.requests_json_response

removed "standard" in es7 template

* added optional headers argument

* using elasticsearch-py instead in metadata_rest_utils.py

* Hc 134 ondemand (#13)

* added check_passthrough_query function for tosca on demand

* working on job_iterator.py changes

* added elasticsearch_utils file

* testing new elasticsearch scrolling in job_iterator

* Hc 142 user rules (#14)

* added safe mode in get_by_id to return False if _id not found in ES

* removed es_type from get_by_id because itll be useless in the future

* added es_type back to get_by_id

* added _doc to get_hysds_io() in resolve mozart_job

* fixed comment in get_by_id function

* Hc 152 container builder (#15)

* moved cofig/es_template_es7.json to es_template.json

* removed es_types from hysds_commons/*_utils.py

* removed extra argument from hysds_commons/metadata_rest_utils.py

* added _doc argument to metadata rest utils

* added warning log to safe mode in get_by_id

* refactored metadata_rest_utils to use elasticsearchh-py lib

* removed hysds_io_type from job_iterator

* Hc 156 elasticsearch (#16)

* consolidate elasticsearch code to one utility class

* optional logging in ElasticsearchUtility

* added better logging and code cleanup

* version 0.2.4 -> 0.3.0 for compatibility

* moved version from 0.2.4 -> 0.3.0

* forgot to logging in elsticsearch_util.py

* fixed small logging bug HC-156_elasticsearch

* added search feature in ElasticsearchUtility and also definition for all methods

* include_source=True

* fixed bugs in elasticsearch_utils and better logging

* added delete_by_query in elasticsearch wrapper class

* refactored job iterator to fix the passthrough query (#17)

* refactored job iterator to fix the passthrough query

* nesting query in rules with one more query key

* nesting query in rules with one more query key

* removed note from delete_by_query

* added more exception handling for when an index is not found in get_by_id (ElasticsearchUtility)

* added more exception handling for when an index is not found in delete_by_id (ElasticsearchUtility)

* added found: false to match elasticsearch's returned error

* edited delete_by_id in ES wrapper class

* removed doc_type from resolve_mozart_job's get_hysds_io (#18)

added more logging in ElasticsearchUtility.get_count
cosmetic changes to code to make it more readable

* removed unused import statement from metadata_rest_utils

* self.logger.exception instead of self.logger.error in ElasticsearchUtility

added TODOs on things that need to be done to consolidate hysds_ios and user_rules to mozart es only

* refactored job_utils.py to read hysds_ios index depending on component field (mozart/grq), also code cleanup

* refactored job_iterator.py to use specific hysds_ios index (hysds_ios-mozart or hysds_ios-grq)

* added elasticsearch_connection file to "initialize" elasticsearch connection

fixed importing HYSDS_IOS_(MOZART | GRQ) VARIABLES FROM app.conf

* removed TODOs

* added logger to elasticsearch_connection