### PR TITLE
Hc 199

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -3,11 +3,9 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-import json
 from elasticsearch import Elasticsearch, NotFoundError, RequestError, ElasticsearchException
 
 standard_library.install_aliases()
-# from requests_aws4auth import AWS4Auth
 
 
 class ElasticsearchUtility:
@@ -22,7 +20,7 @@ class ElasticsearchUtility:
         https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.index
             index – (required) The name of the index
             body – The document
-            id – Document ID
+            id – (optional) Document ID, will use ES generated id if not specified
             refresh – If true then refresh the affected shards to make this operation visible to search
             ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -24,6 +24,7 @@ class ElasticsearchUtility:
             body – The document
             id – Document ID
             refresh – If true then refresh the affected shards to make this operation visible to search
+            ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             result = self.es.index(**kwargs)
@@ -49,6 +50,7 @@ class ElasticsearchUtility:
             allow_no_indices – Ignore if a wildcard expression resolves to no concrete indices (default: false)
             expand_wildcards – Whether wildcard expressions should get expanded to open or closed indices
                 (default: open) Valid choices: open, closed, hidden, none, all Default: open
+            ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             data = self.es.get(**kwargs)
@@ -146,6 +148,7 @@ class ElasticsearchUtility:
             body – A query to restrict the results specified with the Query DSL (optional)
             index – (required) A comma-separated list of indices to restrict the results
             q – Query in the Lucene query string syntax
+            ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             result = self.es.count(**kwargs)
@@ -169,6 +172,7 @@ class ElasticsearchUtility:
             id – The document ID
             doc_type – The type of the document
             refresh – If true then refresh the affected shards to make this operation visible to search
+            ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             if self.logger:
@@ -204,6 +208,7 @@ class ElasticsearchUtility:
             doc_type – The type of the document
             _source – True or false to return the _source field or not, or a list of fields to return
             refresh – If true then refresh the affected shards to make this operation visible to search
+            ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             if self.logger:

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-from elasticsearch import Elasticsearch, NotFoundError, RequestError, ElasticsearchException
-
 standard_library.install_aliases()
+
+from elasticsearch import Elasticsearch, NotFoundError, RequestError, ElasticsearchException
 
 
 class ElasticsearchUtility:
@@ -33,7 +33,7 @@ class ElasticsearchUtility:
             else:
                 print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
             else:
@@ -51,11 +51,9 @@ class ElasticsearchUtility:
             ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
-            data = self.es.get(**kwargs)
             if self.logger:
                 self.logger.info('get_by_id **kwargs: {}'.format(dict(**kwargs)))
-            else:
-                print('get_by_id **kwargs: {}'.format(dict(**kwargs)))
+            data = self.es.get(**kwargs)
             return data
         except NotFoundError as e:
             if self.logger:
@@ -63,7 +61,7 @@ class ElasticsearchUtility:
             else:
                 print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
             else:
@@ -84,25 +82,31 @@ class ElasticsearchUtility:
             size – Number of hits to return (default: 10)
             sort – A comma-separated list of <field>:<direction> pairs
         """
-        documents = []
         if 'scroll' not in kwargs:
             kwargs['scroll'] = '2m'
         if 'size' not in kwargs:
             kwargs['size'] = 100
 
-        if self.logger:
-            self.logger.info('query **kwargs: {}'.format(dict(**kwargs)))
-        else:
-            print('query **kwargs: {}'.format(dict(**kwargs)))
+        documents = []
 
         try:
+            if self.logger:
+                self.logger.info('query **kwargs: {}'.format(dict(**kwargs)))
             page = self.es.search(**kwargs)
             sid = page['_scroll_id']
             documents.extend(page['hits']['hits'])
             page_size = page['hits']['total']['value']
-        except NotFoundError as e:
+        except RequestError as e:
+            if self.logger:
+                self.logger.exception(e)
+            else:
+                print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
+            if self.logger:
+                self.logger.exception(e)
+            else:
+                print(e)
             raise e
 
         if page_size <= len(documents):  # avoid scrolling if we get all data in initial query
@@ -130,15 +134,21 @@ class ElasticsearchUtility:
             sort – A comma-separated list of <field>:<direction> pairs
         """
         try:
+            if self.logger:
+                self.logger.info('search **kwargs: {}'.format(dict(**kwargs)))
             result = self.es.search(**kwargs)
             return result
         except RequestError as e:
             if self.logger:
                 self.logger.exception(e)
+            else:
+                print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
+            else:
+                print(e)
             raise e
 
     def get_count(self, **kwargs):
@@ -151,13 +161,13 @@ class ElasticsearchUtility:
             ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
+            if self.logger:
+                self.logger.info('get_count **kwargs: {}'.format(dict(**kwargs)))
             result = self.es.count(**kwargs)
             if self.logger:
                 self.logger.info('count: {}'.format(result))
-            else:
-                print('count: {}'.format(result))
             return result['count']
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
             else:
@@ -170,15 +180,12 @@ class ElasticsearchUtility:
         https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html
             index – (required) The name of the index
             id – The document ID
-            doc_type – The type of the document
             refresh – If true then refresh the affected shards to make this operation visible to search
             ignore - will not raise error if status code is specified (ex. 404, [400, 404])
         """
         try:
             if self.logger:
                 self.logger.info('query **kwargs: {}'.format(dict(**kwargs)))
-            else:
-                print('query **kwargs: {}'.format(dict(**kwargs)))
             result = self.es.delete(**kwargs)  # index=index, id=_id
             return result
         except NotFoundError as e:
@@ -187,7 +194,7 @@ class ElasticsearchUtility:
             else:
                 print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
             else:
@@ -205,7 +212,6 @@ class ElasticsearchUtility:
                     "doc_as_upsert": true,
                     "doc": <ES document>
                 }
-            doc_type – The type of the document
             _source – True or false to return the _source field or not, or a list of fields to return
             refresh – If true then refresh the affected shards to make this operation visible to search
             ignore - will not raise error if status code is specified (ex. 404, [400, 404])
@@ -213,8 +219,6 @@ class ElasticsearchUtility:
         try:
             if self.logger:
                 self.logger.info('update_document **kwargs'.format(dict(**kwargs)))
-            else:
-                print('update_document **kwargs'.format(dict(**kwargs)))
             result = self.es.update(**kwargs)
             return result
         except RequestError as e:
@@ -223,7 +227,7 @@ class ElasticsearchUtility:
             else:
                 print(e)
             raise e
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             if self.logger:
                 self.logger.exception(e)
             else:

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -77,6 +77,8 @@ class ElasticsearchUtility:
             body – The search definition using the Query DSL
             index – (required) A comma-separated list of index names to search (or aliases)
             _source – True or false to return the _source field or not, or a list of fields to return
+            _source_excludes – A list of fields to exclude from the returned _source field
+            _source_includes – A list of fields to extract and return from the _source field
             q – Query in the Lucene query string syntax
             scroll – Specify how long a consistent view of the index should be maintained for scrolled search
             size – Number of hits to return (default: 10)
@@ -215,10 +217,18 @@ class ElasticsearchUtility:
                 print('update_document **kwargs'.format(dict(**kwargs)))
             result = self.es.update(**kwargs)
             return result
+        except RequestError as e:
+            if self.logger:
+                self.logger.exception(e)
+            else:
+                print(e)
+            raise e
         except ElasticsearchException as e:
             if self.logger:
                 self.logger.exception(e)
-            raise ElasticsearchException(e)
+            else:
+                print(e)
+            raise e
 
 
 # TODO: remove all code that uses this function

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -83,9 +83,9 @@ def iterate(component, rule):
     results = [{"_id": "Transient Faux-Results"}]
     if run_query:
         if component == "mozart" or component == "figaro":
-            results = mozart_es.query(es_index, queryobj)
+            results = mozart_es.query(index=es_index, body=queryobj)
         else:
-            results = grq_es.query(es_index, queryobj)
+            results = grq_es.query(index=es_index, body=queryobj)
 
     # What to iterate for submission
     submission_iterable = [{"_id": "Global Single Submission"}] if single else results

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -65,7 +65,8 @@ def iterate(component, rule):
 
     # Get hysds_ios wiring
     hysds_io_index = HYSDS_IOS_MOZART if component in ('mozart', 'figaro') else HYSDS_IOS_GRQ
-    hysdsio = mozart_es.get_by_id(hysds_io_index, rule["job_type"], _source=False)
+    hysdsio = mozart_es.get_by_id(index=hysds_io_index, id=rule["job_type"])
+    hysdsio = hysdsio['_source']
 
     # Is this a single submission
     passthru = rule.get('passthru_query', False)

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -304,7 +304,8 @@ def resolve_mozart_job(product, rule, hysdsio=None, queue=None, component=None):
             hysds_io_index = 'hysds_ios-grq'
         else:
             hysds_io_index = 'hysds_ios-mozart'
-        hysdsio = mozart_es.get_by_id(hysds_io_index, rule["job_type"], _source=False)
+        hysdsio = mozart_es.get_by_id(index=hysds_io_index, id=rule["job_type"])
+        hysdsio = hysdsio['_source']
 
     # initialize job JSON
     job = {
@@ -363,10 +364,13 @@ def resolve_hysds_job(job_type=None, queue=None, priority=None, tags=None, param
     else:
         raise RuntimeError("Invalid arg type 'params': {} {}".format(type(params), params))
 
-    specification = mozart_es.get_by_id('job_specs', job_type, _source=False)  # pull mozart job and container specs
+    # pull mozart job and container specs
+    specification = mozart_es.get_by_id(index='job_specs', id=job_type)
+    specification = specification['_source']
 
     container_id = specification.get("container", None)
-    container_spec = mozart_es.get_by_id('containers', container_id, _source=False)
+    container_spec = mozart_es.get_by_id(index='containers', id=container_id)
+    container_spec = container_spec['_source']
     logger.info("Running from: {0} in container: {1}".format(job_type, container_id))
 
     # resolve inputs/outputs


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-199
- refactoring `hysds_common`'s `ElasticsearchUtility` to allow for more flexibility
- re-using hysds core's elasticsearch connection because it allows us to read/write to AWS elasticsearch (defined in `.sds/config` and `celeryconfig.py`)
- `lightweight-jobs` will use hysds-core's ES connection

tested `on-demand` and `user_rules` processing in both tosca and figaro