### PR TITLE
cleared scroll in Elasticsearch query method after use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'elasticsearch>=7.0.0,<8.0.0',
         'requests>=2.7.0',
         'future>=0.17.1',
         "jsonschema>=3.0.1"


### PR DESCRIPTION
removed redundant logging in get_count
added elasticsearch-py dependency in setup.py

https://discuss.elastic.co/t/trying-to-create-too-many-scroll-contexts-must-be-less-than-or-equal-to-500-this-limit-can-be-set-by-changing-the-search-max-open-scroll-context-setting/208884/2