### PR TITLE
clear query scroll when all results are returned at once, bump version

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -116,6 +116,7 @@ class ElasticsearchUtility:
             raise e
 
         if page_size <= len(documents):  # avoid scrolling if we get all data in initial query
+            self.es.clear_scroll(scroll_id=sid)
             return documents
 
         while page_size > 0:


### PR DESCRIPTION
getting this error because we're searching for only one record and the `query` method does not clear the scroll when all records are retrieved without scrolling
```
{
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "_id": "NISAR_L0_PR_RRST_VC00_20220108T090433_20220108T091933_D0001_001"
          }
        }
      ]
    }
  },
  "_source": {
    "includes": [
      "daac_delivery_status",
      "daac_catalog_id"
    ]
  }
}
```

```
elasticsearch.exceptions.TransportError: TransportError(500, 'search_phase_execution_exception', 'Trying to create too many scroll contexts. Must be less than or equal to: [500]. This limit can be set by changing the [search.max_open_scroll_context] setting.')
null_resource.mozart (remote-exec): [2020-05-18 21:16:39,750: INFO/backoff/_log_backoff] Backing off check_datasets(...) for 61.1s (elasticsearch.exceptions.TransportError: TransportError(500, 'search_phase_execution_exception', 'Trying to create too many scroll contexts. Must be less than or equal to: [500]. This limit can be set by changing the [search.max_open_scroll_context] setting.'))
```