### PR TITLE
Hc 268

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-268
[lightweight-jobs PR](https://github.com/hysds/lightweight-jobs/pull/21)

```
The initial search request and each subsequent scroll request each return a _scroll_id. 
While the _scroll_id may change between requests, it doesn’t always change — in any 
case, only the most recently received _scroll_id should be used.
```