### PR TITLE
changed elasticsearch import to be compatible with ElasticMock

### DIFF
--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -5,13 +5,13 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-from elasticsearch import Elasticsearch
+import elasticsearch
 from elasticsearch.exceptions import NotFoundError, RequestError, ElasticsearchException
 
 
 class ElasticsearchUtility:
     def __init__(self, es_url, logger=None, **kwargs):
-        self.es = Elasticsearch(hosts=[es_url], **kwargs)
+        self.es = elasticsearch.Elasticsearch(hosts=[es_url], **kwargs)
         self.es_url = es_url
         self.logger = logger
 
@@ -249,7 +249,7 @@ class ElasticsearchUtility:
 
 # TODO: remove all code that uses this function
 def get_es_scrolled_data(es_url, index, query):
-    es = Elasticsearch([es_url])
+    es = elasticsearch.Elasticsearch([es_url])
 
     documents = []
     page = es.search(index=index, scroll='2m', size=100, body=query)


### PR DESCRIPTION
related ticket: https://jira.jpl.nasa.gov/browse/NSDS-1106

Elasticmock: https://pypi.org/project/ElasticMock/
stackoverflow: https://stackoverflow.com/questions/54886640/python-magic-mock-elastic-search-client-calls-not-working-when-using-from-import


example python `unittest`
```
import unittest
from elasticmock import elasticmock

from es_unittest.elasticsearch_utils import ElasticsearchUtility  # should use hysds_commons instead


class TestRostPGE(unittest.TestCase):
    def setUp(self):
        pass

    def tearDown(self):
        pass

    @elasticmock
    def test_es_connection(self):
        client = ElasticsearchUtility('http://localhost:9200')
        print(client.es.info())
        client.es.indices.create("stuff")

        test_data = {
            'x': 1,
            'y': 2,
            'z': 3,
        }
        client.index_document(index='stuff', id='id_1', body=test_data)
        d = client.search(index='stuff')
        d = d['hits']['hits']
        print(d)
        self.assertEqual(1, len(d))
```

output:
```
$ python -m unittest
{'status': 200, 'cluster_name': 'elasticmock', 'version': {'lucene_version': '4.10.4', 'build_hash': '00f95f4ffca6de89d68b7ccaf80d148f1f70e4d4', 'number': '1.7.5', 'build_timestamp': '2016-02-02T09:55:30Z', 'build_snapshot': False}, 'name': 'Nightwatch', 'tagline': 'You Know, for Search'}
[{'_type': '_doc', '_id': 'id_1', '_source': {'x': 1, 'y': 2, 'z': 3}, '_index': 'stuff', '_version': 1, '_score': 1.0}]
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

No need to start Elasticsearch server
```
$ curl localhost:9200
curl: (7) Failed to connect to localhost port 9200: Connection refused
```