### PR TITLE
Hc 332

### DIFF
--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -106,15 +106,11 @@ def iterate(component, rule):
             else:
                 job_name = "%s-single_submission" % job_type
 
-            # disable dedup for passthru single submissions
-            enable_dedup = False if not run_query and single else True
+            # get enable_dedup flag: rule > hysdsio
+            if rule.get("enable_dedup") is None:
+                rule['enable_dedup'] = hysdsio.get("enable_dedup", True)
 
-            # override enable_dedup setting from hysdsio
-            if 'enable_dedup' in hysdsio:
-                enable_dedup = hysdsio['enable_dedup']
-                logger.info("hysdsio overrided enable_dedup: %s" % enable_dedup)
-
-            task_id = submit_mozart_job(product, rule, hysdsio, job_name=job_name, enable_dedup=enable_dedup)
+            task_id = submit_mozart_job(product, rule, hysdsio, job_name=job_name)
             ids.append(task_id)
 
         except Exception as e:

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -108,7 +108,6 @@ def iterate(component, rule):
 
             # disable dedup for passthru single submissions
             enable_dedup = False if not run_query and single else True
-            logger.info("enable_dedup: %s" % enable_dedup)
 
             # override enable_dedup setting from hysdsio
             if 'enable_dedup' in hysdsio:

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -504,6 +504,9 @@ def submit_mozart_job(product, rule, hysdsio=None, queue=None, job_name=None, pa
     moz_job = resolve_mozart_job(product, rule, hysdsio, queue, component=component)
     logger.info("resolved mozart job: {}".format(json.dumps(moz_job)))
 
+    # enable dedup; param overrides hysdsio
+    dedup = moz_job.get('enable_dedup', True) if enable_dedup is None else enable_dedup
+
     # resolve hysds job
     job = resolve_hysds_job(job_type=moz_job['type'],
                             queue=moz_job['queue'],
@@ -512,7 +515,7 @@ def submit_mozart_job(product, rule, hysdsio=None, queue=None, job_name=None, pa
                             params=moz_job['params'],
                             job_name=job_name,
                             payload_hash=payload_hash,
-                            enable_dedup=moz_job['enable_dedup'],
+                            enable_dedup=dedup,
                             username=moz_job['username'],
                             soft_time_limit=moz_job['soft_time_limit'], time_limit=moz_job['time_limit'],
                             disk_usage=moz_job['disk_usage'])

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -337,7 +337,10 @@ def resolve_mozart_job(product, rule, hysdsio=None, queue=None, component=None):
     job["params"] = json.dumps(params)  # set params
 
     # set enable_dedup setting from hysdsio
-    job['enable_dedup'] = rule.get('enable_dedup', hysdsio.get('enable_dedup', True))
+    enable_dedup = rule.get('enable_dedup')  # in case a user rule has 'enable_dedup` set to null
+    if enable_dedup is None:
+        enable_dedup = hysdsio.get('enable_dedup', True)
+    job['enable_dedup'] = enable_dedup
     return job
 
 

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -337,8 +337,7 @@ def resolve_mozart_job(product, rule, hysdsio=None, queue=None, component=None):
     job["params"] = json.dumps(params)  # set params
 
     # set enable_dedup setting from hysdsio
-    if 'enable_dedup' in hysdsio:
-        job['enable_dedup'] = hysdsio['enable_dedup']
+    job['enable_dedup'] = rule.get('enable_dedup', hysdsio.get('enable_dedup', True))
     return job
 
 

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -504,9 +504,6 @@ def submit_mozart_job(product, rule, hysdsio=None, queue=None, job_name=None, pa
     moz_job = resolve_mozart_job(product, rule, hysdsio, queue, component=component)
     logger.info("resolved mozart job: {}".format(json.dumps(moz_job)))
 
-    # enable dedup; param overrides hysdsio
-    dedup = moz_job.get('enable_dedup', True) if enable_dedup is None else enable_dedup
-
     # resolve hysds job
     job = resolve_hysds_job(job_type=moz_job['type'],
                             queue=moz_job['queue'],
@@ -515,7 +512,7 @@ def submit_mozart_job(product, rule, hysdsio=None, queue=None, job_name=None, pa
                             params=moz_job['params'],
                             job_name=job_name,
                             payload_hash=payload_hash,
-                            enable_dedup=dedup,
+                            enable_dedup=moz_job['enable_dedup'],
                             username=moz_job['username'],
                             soft_time_limit=moz_job['soft_time_limit'], time_limit=moz_job['time_limit'],
                             disk_usage=moz_job['disk_usage'])


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-332

- removed multiple checks and setting `enable_dedup` flag, set only in `job_iterator` in the `rule` instead of as a function argument in `submit_mozart_job`
- deprecated the `enable_dedup` flag in `submit_mozart_job`
- calling `resolve_hysds_job` in `submit_mozart_job` a little more readable