### PR TITLE
HC-316 Refactor ElasticsearchUtlility's query method to not use scroll

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-316

In Elasticsearch's scroll [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.1/search-request-scroll.html#search-request-scroll):

> Scrolling is not intended for real time user requests, but rather for processing large amounts of data, e.g. in order to reindex the contents of one index into a new index with a different configuration.

so it's probably safe to say that we should change the query method to use offset and page_size to "scroll" through its records

`elasticsearch-py` [parameters](https://elasticsearch-py.readthedocs.io/en/v7.12.0/api.html#elasticsearch.Elasticsearch.search) for the `search` method:
* `from_` – Starting offset (default: 0)
* `size` – Number of hits to return (default: 10)
