### PR TITLE
pin elasticsearch>=7.0.0,7.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'elasticsearch>=7.0.0,<8.0.0',
+        'elasticsearch>=7.0.0,<7.14.0',
         'requests>=2.7.0',
         'future>=0.17.1',
         "jsonschema>=3.0.1"


### PR DESCRIPTION
related ticket(s): 
* https://jira.jpl.nasa.gov/browse/NSDS-1571
* https://hysds-core.atlassian.net/browse/HC-386

Starting in ES v7.14 it will make a check if the client is compatible and will raise an error 
 https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/release-notes.html#rn-7-14-0

this is because of the conflict between Elastico and AWS

* https://github.com/elastic/elasticsearch-py/blob/61e7a130979edd46af5ead00b03c25f71e0a2886/elasticsearch/transport.py#L412-L413
* https://github.com/elastic/elasticsearch-py/commit/44d9e0de761e17851f29c4d07b6c87ed381fb29e

```python
raise UnsupportedProductError(message)
elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not a supported distribution of Elasticsearch
```

will need to pin the version to `>=7.0.0,<7.14.0` for now, maybe a more long term solution will be viable in the future

affected repos:
* `hysds`: https://github.com/hysds/hysds
* `mozart`: https://github.com/hysds/mozart
* `sdscli`: https://github.com/sdskit/sdscli
* `hysds_commons`: https://github.com/hysds/hysds_commons
* `chimera`: https://github.com/hysds/chimera
* `CNM_product_delivery`: https://github.jpl.nasa.gov/IEMS-SDS/CNM_product_delivery/
* `grq2`: https://github.com/hysds/grq2
* `pele`: https://github.com/hysds/pele
* `pcm_commons`: https://github.jpl.nasa.gov/IEMS-SDS/pcm_commons
* `swot-pcm`: https://github.jpl.nasa.gov/IEMS-SDS/swot-pcm
* `bach-api`: https://github.jpl.nasa.gov/IEMS-SDS/bach-api
* `nisar-bach-api`: https://github.jpl.nasa.gov/IEMS-SDS/nisar-bach-api
