### PR TITLE
HC-415: fix scrolling in ES's query method

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"


### PR DESCRIPTION
jenkins build(s):
- reprocessing - https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/86/
- forward - https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/87/

related tickets(s):
- https://jira.jpl.nasa.gov/browse/NSDS-2102
- https://hysds-core.atlassian.net/browse/HC-415

related PR: https://github.jpl.nasa.gov/IEMS-SDS/nisar-pcm/pull/477

change(s):
- removed usage of storing `scroll_id`s in a `set()`
- optimized the scrolling to clear `scroll_id`'s as they scroll through pages, but only when the `scroll_id` changes
- separated scrolling to a `_scroll` method
- `query` will make an initial check for total records
  - if `>= 10,000` records, it will resort to scrolling (through the `_scroll` method)
  - if `< 10,000` records it will paginate w/ `from_` and `size`
- cleaned up logging
- bumped version