### PR TITLE
NSDS-2170 Created STAC Utility for HySDS Core

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -1,9 +1,12 @@
 import copy
-import os
 import json
+import os
+from shapely.geometry import shape
 from hysds_commons.log_utils import logger
 
 def generate_bbox(coord_list):
+
+# def generate_bbox(coord_list)
 # This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
     '''
     :param coord_list (dict): a list of coordinates where each coordinate is expressed as x, y
@@ -11,8 +14,8 @@ def generate_bbox(coord_list):
     '''
     box = []
     for i in (0, 1):
-        res = sorted(coord_list, key=lambda x: x[i])
-        box.append((res[0][i], res[-1][i]))
+         res = sorted(coord_list, key=lambda x: x[i])
+         box.append((res[0][i], res[-1][i]))
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
@@ -76,7 +79,7 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
         }
 
     # assign to stac to generate_bbox
-    stac_doc["bbox"] = generate_bbox(stac_doc.get("geometry").get("coordinates")[0])
+    stac_doc["bbox"] = list(shape(stac_doc.get("geometry")).bounds)
 
     # Start generating assets
     assets = dict()

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -11,7 +11,7 @@ def bbox(coord_list):
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
-def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path):
+def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage):
     stac_doc = dict()
 
     # Creating stac doc based on mapping configuration of project

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -9,7 +9,7 @@ from hysds_commons.log_utils import logger
 # create list for product lineage
 
 def generate_bbox(coord_list):
-    """This function creates a bbox for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
+    """This function creates a bounding box box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
 
     Parameters
     ----------
@@ -18,7 +18,7 @@ def generate_bbox(coord_list):
     Returns
     -------
     ret
-        the bounding box created for the input polygon
+        the bbox created for the input polygon
     """
 
     box = []

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -8,10 +8,19 @@ from hysds_commons.log_utils import logger
 # read in product_path from _context.json
 # create list for product lineage
 
+def generate_bbox(coord_list):
+    """This function creates a bbox for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
 
-# This function creates a bbox for an input list of coordinates describing a polygon. 
-# The function is called within the create_stac_doc function.
-def bbox(coord_list):
+    Parameters
+    ----------
+    coord_list (list) - a list of coordinates where each coordinate is expressed as x, y
+
+    Returns
+    -------
+    ret
+        the bounding box created for the input polygon
+    """
+
     box = []
     for i in (0, 1):
         res = sorted(coord_list, key=lambda x: x[i])
@@ -19,10 +28,27 @@ def bbox(coord_list):
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
-# This function generate takes in the product metadata and 
-# project configuration files to return a STAC document.
+
 def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage):
     stac_doc = dict()
+    """This function generate takes in the product metadata and project configuration files to return a STAC document.
+    
+    Parameters
+    ----------
+
+    product_directory (str) - Name of product downloaded into work directory
+    metadata (dict) - .met.json file content of the product
+    mapping (dict) - file content of stac_mappings.json
+    assets_desc (dict) - file content of assets_description.json
+    product_type (str) - product / dataset type
+    product_path (str) - S3 location or URL of product
+    lineage (list) - list of URLs pointing to location of every file used as input to generate the product
+
+    Returns
+    -------
+    ret
+        it is the STAC JSON for the input product, compliant with STAC requirements for an item
+    """
 
     # Creating stac doc based on mapping configuration of project
     # 'field_mappings' Defines a 1:1 mapping between the expected field name in STAC to the 
@@ -97,16 +123,4 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
 
     logger.info("created stac document: %s" % json.dumps(stac_doc, indent=4))
 
-    # return stac_doc, it is a dictionary, it is the STAC JSON for the 
-    # input product, compliant with STAC requirements for an item
     return stac_doc
-
-
-# Parameter description from create_stac_doc:
-# product_directory (str) - Name of product downloaded into work directory
-# metadata (dict) - .met.json file content of the product
-# mapping (dict) - file content of stac_mappings.json
-# assets_desc (dict) - file content of assets_description.json
-# product_type (str) - product / dataset type
-# product_path (str) - S3 location or URL of product
-# lineage (list) - list of URLs pointing to location of every file used as input to generate the product

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -1,0 +1,86 @@
+import copy
+import os
+import json
+from hysds_commons.log_utils import logger
+
+def bbox(coord_list):
+    box = []
+    for i in (0, 1):
+        res = sorted(coord_list, key=lambda x: x[i])
+        box.append((res[0][i], res[-1][i]))
+    ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
+    return ret
+
+def create_stac_doc(product_directory, metadata, mapping, assets_desc):
+    stac_doc = dict()
+
+    # Creating stac doc based on mapping configuration of project
+    field_mapping = mapping.get("field_mappings")
+    for k in field_mapping:
+        stac_doc[k] = metadata.get(field_mapping.get(k))
+
+    stac_links = []
+    code_mapping = mapping.get("code_mappings")
+    for k in code_mapping:
+        stac_doc[k] = eval(str(code_mapping.get(k)))
+        # set up links
+        if k == "links":
+            for l in code_mapping.get("links"):
+                link = dict()
+                link["ref"] = l
+                if l == "root":
+                    link["href"] = code_mapping.get("links").get("root")
+                else:
+                    link["href"] = eval(code_mapping.get("links").get(l))
+                stac_links.append(link)
+            stac_doc["links"] = stac_links
+
+    # Creating properties. Copy over all the metadata except Product ID and Geo
+    properties = copy.deepcopy(metadata)
+    del properties[field_mapping.get("id")]
+    # Not every product will have bounding polygon
+    try:
+        del properties[field_mapping.get("geometry")]
+    except KeyError:
+        logger.info("Bounding Polygon not found in metadata. Setting to global extent")
+    stac_doc["properties"] = properties
+
+    # Set geometry, if doesn't exist in product then set to world
+    if metadata.get(field_mapping.get("geometry")) is not None:
+        stac_doc["geometry"] = metadata.get(field_mapping.get("geometry"))
+    else:
+        stac_doc["geometry"] = {
+            "type": "Polygon",
+            "coordinates": [[[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]]
+        }
+
+    # assign to stac.bbox
+    stac_doc["bbox"] = bbox(stac_doc.get("geometry").get("coordinates")[0])
+
+    # Start generating assets.
+    assets = dict()
+
+    # get assets description based on product type
+    product_type = eval(mapping.get("other_mappings").get("product_type"))
+    prod_desc = assets_desc.get(product_type)
+
+    # Get list of filenames in product dir
+    files = os.listdir(product_directory)
+
+    # iterate over file info for a product type
+    for file_ext in prod_desc:
+        file_info = prod_desc.get(file_ext)
+        for file in files:
+            if file.endswith(file_ext):
+                assets_key = file_info.get("name")
+                assets_value = {
+                    "href": file,
+                    "title": file_info.get("title"),
+                    "type": file_info.get("type")
+                }
+                assets[assets_key] = assets_value
+    stac_doc["assets"] = assets
+
+    logger.info("created stac document: %s" % json.dumps(stac_doc, indent=4))
+
+    return stac_doc

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -11,7 +11,7 @@ def bbox(coord_list):
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
-def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, context):
+def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path):
     stac_doc = dict()
 
     # Creating stac doc based on mapping configuration of project
@@ -59,8 +59,6 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
 
     # Start generating assets.
     assets = dict()
-
-    product_path = context.get("localize_urls")[0]
 
     # get assets description based on product type
     prod_desc = assets_desc.get(product_type)

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -9,7 +9,7 @@ from hysds_commons.log_utils import logger
 # create list for product lineage
 
 def generate_bbox(coord_list):
-    """This function creates a bounding box box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
+    """This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
 
     Parameters
     ----------

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -4,25 +4,11 @@ import os
 from shapely.geometry import shape
 from hysds_commons.log_utils import logger
 
-def generate_bbox(coord_list):
-
-# def generate_bbox(coord_list)
-# This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
-    '''
-    :param coord_list (dict): a list of coordinates where each coordinate is expressed as x, y
-    :return ret (list): the bbox created for the input polygon
-    '''
-    box = []
-    for i in (0, 1):
-         res = sorted(coord_list, key=lambda x: x[i])
-         box.append((res[0][i], res[-1][i]))
-    ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
-    return ret
-
 
 def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage):
-    stac_doc = dict()
+    
     '''
+    Creating stac doc based on mapping configuration of project
     :param product_directroy (str): Name of product downloaded into work directory
     :param metadata (dict): .met.json file content of the product
     :param mapping (dict): file content of stac_mappings.json
@@ -32,8 +18,8 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
     :param lineage (list): list of URLs pointing to location of every file used as input to generate the product
     :return stac_doc (dict): it is the STAC JSON for the input product, compliant with STAC requirements for an item
     '''
+    stac_doc = dict()
 
-    # Creating stac doc based on mapping configuration of project
     # 'field_mappings' Defines a 1:1 mapping between the expected field name in STAC to the 
     # metadata key found in the product's met.json file.
     field_mapping = mapping.get("field_mappings")
@@ -78,7 +64,7 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
             "coordinates": [[[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]]
         }
 
-    # assign to stac to generate_bbox
+    # generate bbox with shapely library
     stac_doc["bbox"] = list(shape(stac_doc.get("geometry")).bounds)
 
     # Start generating assets

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -4,18 +4,11 @@ import json
 from hysds_commons.log_utils import logger
 
 def generate_bbox(coord_list):
-    """This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
-
-    Parameters
-    ----------
-    coord_list (list) - a list of coordinates where each coordinate is expressed as x, y
-
-    Returns
-    -------
-    ret
-        the bbox created for the input polygon
-    """
-
+# This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
+    '''
+    :param coord_list (dict): a list of coordinates where each coordinate is expressed as x, y
+    :return ret (list): the bbox created for the input polygon
+    '''
     box = []
     for i in (0, 1):
         res = sorted(coord_list, key=lambda x: x[i])
@@ -26,24 +19,16 @@ def generate_bbox(coord_list):
 
 def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage):
     stac_doc = dict()
-    """This function generate takes in the product metadata and project configuration files to return a STAC document.
-    
-    Parameters
-    ----------
-
-    product_directory (str) - Name of product downloaded into work directory
-    metadata (dict) - .met.json file content of the product
-    mapping (dict) - file content of stac_mappings.json
-    assets_desc (dict) - file content of assets_description.json
-    product_type (str) - product / dataset type
-    product_path (str) - S3 location or URL of product
-    lineage (list) - list of URLs pointing to location of every file used as input to generate the product
-
-    Returns
-    -------
-    stac_doc
-        it is the STAC JSON for the input product, compliant with STAC requirements for an item
-    """
+    '''
+    :param product_directroy (str): Name of product downloaded into work directory
+    :param metadata (dict): .met.json file content of the product
+    :param mapping (dict): file content of stac_mappings.json
+    :param assets_desc (dict): file content of assets_description.json
+    :param product_type (str): product / dataset type
+    :param product_path (str): S3 location or URL of product
+    :param lineage (list): list of URLs pointing to location of every file used as input to generate the product
+    :return stac_doc (dict): it is the STAC JSON for the input product, compliant with STAC requirements for an item
+    '''
 
     # Creating stac doc based on mapping configuration of project
     # 'field_mappings' Defines a 1:1 mapping between the expected field name in STAC to the 
@@ -90,8 +75,8 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
             "coordinates": [[[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]]
         }
 
-    # assign to stac to bbox
-    stac_doc["bbox"] = bbox(stac_doc.get("geometry").get("coordinates")[0])
+    # assign to stac to generate_bbox
+    stac_doc["bbox"] = generate_bbox(stac_doc.get("geometry").get("coordinates")[0])
 
     # Start generating assets
     assets = dict()

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -11,7 +11,7 @@ def bbox(coord_list):
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
-def create_stac_doc(product_directory, metadata, mapping, assets_desc):
+def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, context):
     stac_doc = dict()
 
     # Creating stac doc based on mapping configuration of project
@@ -60,8 +60,9 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc):
     # Start generating assets.
     assets = dict()
 
+    product_path = context.get("localize_urls")[0]
+
     # get assets description based on product type
-    product_type = eval(mapping.get("other_mappings").get("product_type"))
     prod_desc = assets_desc.get(product_type)
 
     # Get list of filenames in product dir
@@ -74,7 +75,7 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc):
             if file.endswith(file_ext):
                 assets_key = file_info.get("name")
                 assets_value = {
-                    "href": file,
+                    "href": f"{product_path}/{file}",
                     "title": file_info.get("title"),
                     "type": file_info.get("type")
                 }

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -3,11 +3,6 @@ import os
 import json
 from hysds_commons.log_utils import logger
 
-# load project configuration files
-# load product metadata file
-# read in product_path from _context.json
-# create list for product lineage
-
 def generate_bbox(coord_list):
     """This function creates a bounding box for an input list of coordinates describing a polygon.  The function is called within the create_stac_doc function.
 

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -46,7 +46,7 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
 
     Returns
     -------
-    ret
+    stac_doc
         it is the STAC JSON for the input product, compliant with STAC requirements for an item
     """
 

--- a/hysds_commons/stac_utils.py
+++ b/hysds_commons/stac_utils.py
@@ -3,6 +3,14 @@ import os
 import json
 from hysds_commons.log_utils import logger
 
+# load project configuration files
+# load product metadata file
+# read in product_path from _context.json
+# create list for product lineage
+
+
+# This function creates a bbox for an input list of coordinates describing a polygon. 
+# The function is called within the create_stac_doc function.
 def bbox(coord_list):
     box = []
     for i in (0, 1):
@@ -11,15 +19,22 @@ def bbox(coord_list):
     ret = f"({box[0][0]}, {box[1][0]}, {box[0][1]}, {box[1][1]})"
     return ret
 
+# This function generate takes in the product metadata and 
+# project configuration files to return a STAC document.
 def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage):
     stac_doc = dict()
 
     # Creating stac doc based on mapping configuration of project
+    # 'field_mappings' Defines a 1:1 mapping between the expected field name in STAC to the 
+    # metadata key found in the product's met.json file.
     field_mapping = mapping.get("field_mappings")
     for k in field_mapping:
         stac_doc[k] = metadata.get(field_mapping.get(k))
 
     stac_links = []
+    # 'code_mappings' derives values for certain STAC fields when they are not straight forward mappings. 
+    # The value provided is a python code snippet which is evaluated in the create_stac_doc 
+    # function.
     code_mapping = mapping.get("code_mappings")
     for k in code_mapping:
         stac_doc[k] = eval(str(code_mapping.get(k)))
@@ -35,17 +50,17 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
                 stac_links.append(link)
             stac_doc["links"] = stac_links
 
-    # Creating properties. Copy over all the metadata except Product ID and Geo
+    # Creating properties. Copy over all the metadata EXCLUDING Properties and Geometry
     properties = copy.deepcopy(metadata)
     del properties[field_mapping.get("id")]
-    # Not every product will have bounding polygon
+    # This try-except block is included because not every product will have bounding polygon
     try:
         del properties[field_mapping.get("geometry")]
     except KeyError:
         logger.info("Bounding Polygon not found in metadata. Setting to global extent")
     stac_doc["properties"] = properties
 
-    # Set geometry, if doesn't exist in product then set to world
+    # Set geometry, if doesn't exist in product then set to global coordinates
     if metadata.get(field_mapping.get("geometry")) is not None:
         stac_doc["geometry"] = metadata.get(field_mapping.get("geometry"))
     else:
@@ -54,10 +69,10 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
             "coordinates": [[[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]]
         }
 
-    # assign to stac.bbox
+    # assign to stac to bbox
     stac_doc["bbox"] = bbox(stac_doc.get("geometry").get("coordinates")[0])
 
-    # Start generating assets.
+    # Start generating assets
     assets = dict()
 
     # get assets description based on product type
@@ -82,4 +97,16 @@ def create_stac_doc(product_directory, metadata, mapping, assets_desc, product_t
 
     logger.info("created stac document: %s" % json.dumps(stac_doc, indent=4))
 
+    # return stac_doc, it is a dictionary, it is the STAC JSON for the 
+    # input product, compliant with STAC requirements for an item
     return stac_doc
+
+
+# Parameter description from create_stac_doc:
+# product_directory (str) - Name of product downloaded into work directory
+# metadata (dict) - .met.json file content of the product
+# mapping (dict) - file content of stac_mappings.json
+# assets_desc (dict) - file content of assets_description.json
+# product_type (str) - product / dataset type
+# product_path (str) - S3 location or URL of product
+# lineage (list) - list of URLs pointing to location of every file used as input to generate the product

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'elasticsearch>=7.0.0,<7.14.0',
         'requests>=2.7.0',
         'future>=0.17.1',
-        "jsonschema>=3.0.1"
+        "jsonschema>=3.0.1",
+        "shapely>=1.8.2"
     ]
 )


### PR DESCRIPTION
**Purpose:** Added a new utility to generate STAC compliant document for HySDS datasets. This utility has been generalized such that any project can utilize this.

**References**:
-  [STAC Specifications](https://github.com/radiantearth/stac-spec)
- [STAC Example Documents](https://github.com/stac-utils/stac-examples)
- [STAC Example USGS Landsat](https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/tm/1990/008/008/LT05_L2SP_008008_19900421_20200916_02_T2)
- [JSON Schema for STAC Item](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/json-schema/catalog.json)

#### STAC Utility Functions:
- `create_stac_doc()`: This function generate takes in the product metadata and project configuration files to return a STAC document.


### How to use STAC Utility in a project

The following files and code should be added in the project's repository.

#### Pre-requisites

#### Project Configuration Files:

**1. STAC Mappings File**
This configuration file contains two sections that provide mappings of product metadata to STAC format. 

- The `field_mappings` section defines a 1:1 mapping between the expected field name in STAC to the metadata key found in the product's `met.json` file.
- The `code_mappings` section  defines how to derive values for certain STAC fields when they are not straight forward mappings. The value provided is a python code snippet which is evaluated in the `create_stac_doc` function.

Template:
```json
{
    "field_mappings": {
      "STAC_field_name1": "product_metadata_key1",
      "STAC_field_name2": "product_metadata_key2"
    },
    "code_mappings": {
      "STAC_field_name": "python code to evaluate to derive value",
    }
}

```

Example:
```json
{
    "field_mappings": {
      "id": "id",
      "geometry": "Bounding_Polygon"
    },
    "code_mappings": {
      "collection": "'NISAR_{}'.format(metadata.get('product_type'))",
    }
}

```

#### 2. **Assets Description File**
This configuration file provides information describing the files associated with each product type.

Template:
```json
{
    "dataset_type": {
     "file_ext":
     {
       "name": "FileShortName",
       "title": "Description of File",
       "type": "MIME Type"
     }
}
```

Example:
```json
{
    "LOA_L_RRST_PP": {
     ".context.json":
     {
       "name": "ContextFile",
       "title": "PGE job context file",
       "type": "application/json"
     }
}
```

#### Usage

#### Python Script
Simply import the `stac_utils` in your python script and call with `create_stac_doc()` the required input parameters.

```
create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage)

Parameter description:
product_directory (str) - Name of product downloaded into work directory
metadata (dict) - .met.json file content of the product
mapping (dict) - file content of stac_mappings.json
assets_desc (dict) - file content of assets_description.json
product_type (str) - product / dataset type
product_path (str) - S3 location or URL of product
lineage (list) - list of URLs pointing to location of every file used as input to generate the product
```

#### Python Code Snippet
```
from hysds_commons.stac_utils import create_stac_doc

# load project configuration files
# load product metadata file
# read in product_path from _context.json
# create list for product lineage

stac_doc = create_stac_doc(product_directory, metadata, mapping, assets_desc, product_type, product_path, lineage)

# write stac_doc to a JSON file
```
