### PR TITLE
HC-435: Upgrade Elasticsearch 7.9 -> 7.10

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -154,7 +154,7 @@ class ElasticsearchUtility:
         """
         page_limit = 10000
         if "size" not in kwargs and "size" not in kwargs.get("body", {}):
-            kwargs["size"] = 500
+            kwargs["size"] = 1000
         else:
             kwargs["size"] = kwargs.get("size") or kwargs.get("body", {}).get("size", 1000)
         scroll = kwargs.pop("scroll", "2m")

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -15,7 +15,12 @@ class ElasticsearchUtility:
         self.es = elasticsearch.Elasticsearch(hosts=[es_url], **kwargs)
         self.es_url = es_url
         self.logger = logger
+        self.version = None
 
+    def set_es_version(self):
+        """
+        Sets the version of elasticsearch; ex. 7.10.2
+        """
         es_info = self.es.info()
         self.version = version.parse(es_info["version"]["number"])
 
@@ -162,6 +167,8 @@ class ElasticsearchUtility:
         total = data["hits"]["total"]["value"]
 
         if total >= page_limit:
+            if self.version is None:
+                self.set_es_version()
             if self.version >= version.parse("7.10"):
                 return self._pit(**kwargs)
             else:


### PR DESCRIPTION
related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-435
- https://jira.jpl.nasa.gov/browse/NSDS-2302

related PR(s):
- https://github.com/hysds/hysds/pull/146

change(s):
- the `query` method will use the PIT + `search_after` API when using es >=7.10, scroll API if <7.10
- bump version