### PR TITLE
fix for optional params in resolve_mozart_job()

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -51,13 +51,13 @@ def get_hysds_io_params(job_spec):
     """
     hysdsio_params = dict()
     optional_params = set()
-    hysdsio_name = job_spec.replace("job", "hysds-io")
+    hysdsio_name = job_spec.replace("job", "hysds-io", 1)
 
     hysds_io = mozart_es.get_by_id(index="hysds_ios-grq", id=hysdsio_name, ignore=[404])
     if hysds_io["found"] is False:
         hysds_io = mozart_es.get_by_id(index="hysds_ios-mozart", id=hysdsio_name, ignore=[404])
         if hysds_io["found"] is False:
-            return set()
+            raise ValueError("hysds-ios not found: %s" % hysdsio_name)
     params = hysds_io["_source"]["params"]
     for param in params:
         param_name = param["name"]
@@ -162,10 +162,10 @@ def get_inputs(param, kwargs, rule=None, product=None):
         return ret
 
     source = param.get("from", "unknown")
-    ret = param.get("default_value", None)  # Get a value
+    ret = param.get("default", None)  # Get a value TODO: should this be "default" instead?
 
     if source == "submitter":
-        ret = kwargs.get(param.get("name", "unknown"), None)
+        ret = kwargs.get(param.get("name", "unknown"), ret)
     elif source == "passthrough" and not rule is None:
         ret = rule.get(param["name"], None)
     elif source.startswith("dataset_jpath:") and not product is None:

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -162,7 +162,7 @@ def get_inputs(param, kwargs, rule=None, product=None):
         return ret
 
     source = param.get("from", "unknown")
-    ret = param.get("default", None)  # Get a value TODO: should this be "default" instead?
+    ret = param.get("default", None)  # Get a value
 
     if source == "submitter":
         ret = kwargs.get(param.get("name", "unknown"), ret)


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-442

fwd - [![Build Status](https://nisar-pcm-ci.jpl.nasa.gov/buildStatus/icon?job=force-branches%2Fmkarim-force_branch-E2E-test&build=476)](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/mkarim-force_branch-E2E-test/476/)
reproc - [![Build Status](https://nisar-pcm-ci.jpl.nasa.gov/buildStatus/icon?job=force-branches%2Fkyndallj-force_branch-E2E-test&build=6)](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/kyndallj-force_branch-E2E-test/6/)

changes:
- the string replace in `get_hysds_io_params()` will replace **all** occurrences of the word "job" with "hysds-io" when it should only be the first occurrence
- when checking for default values in `get_inputs()` the field should be `default` instead of `default_value`, this will default to `None` every time and it will convert it to an empty string

testing on my cluster with additional logging:

the params:
```json
[
  {
    "name": "optional_bool",
    "from": "submitter",
    "placeholder": "optional boolean parameter",
    "type": "boolean",
    "optional": true
  },
  {
    "name": "optional_bool_with_default",
    "from": "submitter",
    "placeholder": "optional boolean parameter w/ default value",
    "type": "boolean",
    "default": "false",
    "optional": true
  },
  {
    "name": "optional_text",
    "from": "submitter",
    "placeholder": "optional string parameter",
    "type": "text",
    "optional": true
  },
  {
    "name": "optional_text_with_default",
    "from": "submitter",
    "placeholder": "optional string parameter",
    "type": "text",
    "default": "foo",
    "optional": true
  }
]
```

the user rules has the `kwargs` with no values passed for the `optional_text_with_default` param:
```
{'optional_bool_with_default': 'true'}
```

the logs from `user_rules_trigger-**.log`
```
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (kwargs): {'optional_bool_with_default': 'true'}
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (get_inputs) ret: foo
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (get_inputs) submitter: ret foo
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (get_inputs - end): ret: foo
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (get_inputs): optional_text_with_default: foo (<class 'str'>)
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (run_type_conversion): optional_text_with_default: foo (<class 'str'>)
[2022-11-17 20:16:13,836: INFO/ForkPoolWorker-1] # (run_lambda): optional_text_with_default: foo (<class 'str'>)
```

the params end up being:
```
params: {
  "optional_bool": "",
  "optional_bool_with_default": true,
  "optional_text": "",
  "optional_text_with_default": "foo"  # <-----
}
```