### PR TITLE
HC-431 - Make hysds-framework conda installable 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -46,7 +46,7 @@ jobs:
             pytest .
   publish-pypi:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ workflows:
           context:
             - docker-hub-creds
             - git-oauth-token
-            - pypi-creds
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -113,6 +112,7 @@ workflows:
           context:
             - docker-hub-creds
             - git-oauth-token
+            - pypi-creds
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo apt update -y
             sudo apt install iproute2
             pip install pytest==7.2.0
             pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,51 @@ jobs:
           path: test-reports
 
       - store_artifacts:
-          path: test-reports    
+          path: test-reports
+
+  build:
+    docker:
+      - image: circleci/python:3.9
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            sudo apt install iproute2
+            pip install pytest==7.2.0
+            pip install .
+      - run:
+          name: pytest
+          command: |
+            pytest .
+  publish-pypi:
+    docker:
+      - image: circleci/python:3.9
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout
+      - run:
+          name: Init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "repository: https://upload.pypi.org/legacy/" >> ~/.pypirc
+            echo -e "username: $PYPI_USER" >> ~/.pypirc
+            echo -e "password: $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: Install tools
+          command: |
+            pip install twine==4.0.2
+      - run:
+          name: Install and publish to PyPI
+          command: |
+            pip install .
+            python setup.py sdist bdist_wheel
+            twine upload dist/* --verbose --config-file ~/.pypirc
 
 
 workflows:
@@ -35,6 +79,7 @@ workflows:
           context:
             - docker-hub-creds
             - git-oauth-token
+
   weekly:
     triggers:
       - schedule:
@@ -51,3 +96,22 @@ workflows:
           filters:
             branches:
               only: develop
+
+  build-and-deploy:
+    jobs:
+      - build:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
+            - pypi-creds
+      - publish-pypi:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,11 @@ workflows:
             - docker-hub-creds
             - git-oauth-token
             - pypi-creds
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
       - publish-pypi:
           context:
             - docker-hub-creds

--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,18 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 import hysds_commons
 
+
+def readme():
+    with open("README.md") as f:
+        return f.read()
+
+
 setup(
     name='hysds_commons',
     version=hysds_commons.__version__,
-    long_description=hysds_commons.__description__,
+    description=hysds_commons.__description__,
+    long_description_content_type="text/markdown",
+    long_description=readme(),
     url=hysds_commons.__url__,
     packages=find_packages(),
     include_package_data=True,
@@ -19,5 +27,20 @@ setup(
         'future>=0.17.1',
         "jsonschema>=3.0.1",
         "shapely>=1.8.2"
-    ]
+    ],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Unix",
+        "Operating System :: MacOS :: MacOS X",
+    ],
 )


### PR DESCRIPTION
ticket: https://hysds-core.atlassian.net/browse/HC-431
https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/2045837313/Publishing+HySDS+core+packages+to+PyPI

changes:
- added more to `.gitignore`
- added a new CircleCI workflow
  - build & unit test the package
  - publish to PyPI servers
- edited `setup.py` to better display in PyPI page
- bump version
