### PR TITLE
Add flexibility to ES sort in search_by_id()

### DIFF
--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -83,7 +83,7 @@ class ElasticsearchUtility:
             raise RuntimeError("index key argument must be supplied")
 
         ignore = kwargs.get("ignore", None)
-        kwargs["sort"] = "@timestamp:desc"
+        kwargs["sort"] = kwargs.get("sort", "@timestamp:desc")
 
         return_all = kwargs.pop("return_all", False)
 


### PR DESCRIPTION
## Overview

- As part of [SSDS-3127 (Split GBE tile indices by month)](https://jira.jpl.nasa.gov/browse/SSDS-3127), several calls to `get_by_id` were replaced with `search_by_id`. During testing, it was found that `search_by_id` used a fixed default value of `@timestamp:desc` for the `sort` argument used in the ES search call.
- This fixed default value caused issues in the case of SWOT PCM's GBE indices, as they do not contain a `timestamp` field, rather, they contain `tileStartTime` and `tileEndTime`. For this reason, we needed to add flexibility for default the value of the query's `sort` parameter.
- Please refer to the related PR in the swot-pcm repo for the corresponding force branches and verification process.
  - https://github.jpl.nasa.gov/IEMS-SDS/swot-pcm/pull/539
