### PR TITLE
hot-update: bump version

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.14"
+__version__ = "1.0.15"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"


### PR DESCRIPTION
This hot update bumps the version since we made an update since the latest release: https://github.com/hysds/hysds_commons/pull/53