### PR TITLE
HC-487: Test out and deploy locally a Elasticsearch service in clustered mode (multi-node)

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.15"
+__version__ = "1.0.16"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/elasticsearch_utils.py
+++ b/hysds_commons/elasticsearch_utils.py
@@ -12,7 +12,7 @@ from elasticsearch.exceptions import NotFoundError, RequestError, ElasticsearchE
 
 class ElasticsearchUtility:
     def __init__(self, es_url, logger=None, **kwargs):
-        self.es = elasticsearch.Elasticsearch(hosts=[es_url], **kwargs)
+        self.es = elasticsearch.Elasticsearch(hosts=es_url if type(es_url) == list else [es_url], **kwargs)
         self.es_url = es_url
         self.logger = logger
         self.version = None


### PR DESCRIPTION
- This PR adds support for operating Elasticsearch in clustered mode. The ES cluster is composed of nodes on mozart, grq, and metrics. With this PR, Elasticsearch can still be operated in a non-clustered mode.
- This addition has been tested in SWOT PCM by restoring a snapshot from operational in flight data and performing the SWOT PCM smoke test. To make sure these updates are backwards compatible, @mcayanan is currently running [a force branch on the NISAR side](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/mkarim-force_branch-E2E-test/231/).