### PR TITLE
HC-503: Fixed an issue where job_iterator could return duplicate results

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -81,12 +81,14 @@ def iterate(component, rule):
 
     # Run the query to get the products; for efficiency, run query only if we need the results
     results = [{"_id": "Transient Faux-Results"}]
-    sort = ["@timestamp:desc", "id.keyword:asc"]
+    #sort = ["@timestamp:desc", "id.keyword:asc"]
     if run_query:
         if component == "mozart" or component == "figaro":
-            results = mozart_es.query(index=es_index, body=queryobj, sort=sort)
+            results = mozart_es.query(index=es_index, body=queryobj)
+            # results = mozart_es.query(index=es_index, body=queryobj, sort=sort)
         else:
-            results = grq_es.query(index=es_index, body=queryobj, sort=sort)
+            results = grq_es.query(index=es_index, body=queryobj)
+            # results = grq_es.query(index=es_index, body=queryobj, sort=sort)
 
     unique_results = {}
     for result in results:

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -81,14 +81,12 @@ def iterate(component, rule):
 
     # Run the query to get the products; for efficiency, run query only if we need the results
     results = [{"_id": "Transient Faux-Results"}]
-    #sort = ["@timestamp:desc", "id.keyword:asc"]
+    sort = ["@timestamp:desc", "id.keyword:asc"]
     if run_query:
         if component == "mozart" or component == "figaro":
-            results = mozart_es.query(index=es_index, body=queryobj)
-            # results = mozart_es.query(index=es_index, body=queryobj, sort=sort)
+            results = mozart_es.query(index=es_index, body=queryobj, sort=sort)
         else:
-            results = grq_es.query(index=es_index, body=queryobj)
-            # results = grq_es.query(index=es_index, body=queryobj, sort=sort)
+            results = grq_es.query(index=es_index, body=queryobj, sort=sort)
 
     unique_results = {}
     for result in results:

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -88,25 +88,6 @@ def iterate(component, rule):
         else:
             results = grq_es.query(index=es_index, body=queryobj, sort=sort)
 
-    unique_results = {}
-    for result in results:
-        id = result.get("_id")
-        if id in unique_results:
-            unique_results[id] += 1
-        else:
-            unique_results[id] = 1
-
-    duplicate_ids = list()
-    for key, value in unique_results.items():
-        if value > 1:
-            duplicate_ids.append(key)
-
-    if duplicate_ids:
-        logger.info(f"List of duplicate IDs: {duplicate_ids}")
-        raise Exception(f"found duplicate IDs in result set: {duplicate_ids}")
-    else:
-        logger.info(f"dictionary of unique_results:\n{unique_results}")
-
     # What to iterate for submission
     submission_iterable = [{"_id": "Global Single Submission"}] if single else results
 

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -81,11 +81,12 @@ def iterate(component, rule):
 
     # Run the query to get the products; for efficiency, run query only if we need the results
     results = [{"_id": "Transient Faux-Results"}]
+    sort = [{"@timestamp": "desc"}, {"id.keyword": "asc"}]
     if run_query:
         if component == "mozart" or component == "figaro":
-            results = mozart_es.query(index=es_index, body=queryobj)
+            results = mozart_es.query(index=es_index, body=queryobj, sort=sort)
         else:
-            results = grq_es.query(index=es_index, body=queryobj)
+            results = grq_es.query(index=es_index, body=queryobj, sort=sort)
 
     # What to iterate for submission
     submission_iterable = [{"_id": "Global Single Submission"}] if single else results

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -88,6 +88,24 @@ def iterate(component, rule):
         else:
             results = grq_es.query(index=es_index, body=queryobj, sort=sort)
 
+    unique_results = {}
+    for result in results:
+        id = result.get("_id")
+        if id in unique_results:
+            unique_results[id] += 1
+        else:
+            unique_results[id] = 1
+
+    duplicate_ids = list()
+    for key, value in unique_results.items():
+        if value > 1:
+            duplicate_ids.append(key)
+
+    if duplicate_ids:
+        logger.info(f"List of duplicate IDs: {duplicate_ids}")
+        raise Exception(f"found duplicate IDs in result set: {duplicate_ids}")
+
+
     # What to iterate for submission
     submission_iterable = [{"_id": "Global Single Submission"}] if single else results
 

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -106,7 +106,8 @@ def iterate(component, rule):
     if duplicate_ids:
         logger.info(f"List of duplicate IDs: {duplicate_ids}")
         raise Exception(f"found duplicate IDs in result set: {duplicate_ids}")
-
+    else:
+        logger.info(f"dictionary of unique_results:\n{unique_results}")
 
     # What to iterate for submission
     submission_iterable = [{"_id": "Global Single Submission"}] if single else results

--- a/hysds_commons/job_iterator.py
+++ b/hysds_commons/job_iterator.py
@@ -81,7 +81,7 @@ def iterate(component, rule):
 
     # Run the query to get the products; for efficiency, run query only if we need the results
     results = [{"_id": "Transient Faux-Results"}]
-    sort = [{"@timestamp": "desc"}, {"id.keyword": "asc"}]
+    sort = ["@timestamp:desc", "id.keyword:asc"]
     if run_query:
         if component == "mozart" or component == "figaro":
             results = mozart_es.query(index=es_index, body=queryobj, sort=sort)


### PR DESCRIPTION
This PR fixes an issue that was seen on SWOT where a large retry job was mistakingly trying to retry some jobs multiple times. In order to resolve this, the job_iterator needed to be updated such that when it makes a query to GRQ or Mozart, it passes the `sort` argument to the `query` function as the query function can paginate over results greater than 1000. Adding the sort ensures that as the query function makes subsequent search calls, the results are sorted in such a way that we don't mistakingly add a result from a previous query into the aggregated list.

To test, I added a kludge in the code temporarily to detect the duplicates. See:
- 1e958621a8c0636ad022337864e0123cf62feac1
- 4334c03b18c70a2befdcc34bc64e2618a985c151

Then I ran a retry job and verified that the un-sorting of the query resulted in duplicate results being returned:
![image](https://github.com/hysds/hysds_commons/assets/42812746/7cadadcb-154e-4670-9943-0565ec6e3cd3)
![image](https://github.com/hysds/hysds_commons/assets/42812746/1c56da05-bf05-41c9-91d1-22281731513a)


Removed the kludge, added the sort to the query, then re-ran the same retry job and verified that it returned unique results:
![image](https://github.com/hysds/hysds_commons/assets/42812746/6fee7811-721f-4a4a-9af1-fd2708cc7bcc)
