### PR TITLE
HC-526: Fix search_by_id function to not throw KeyError: 'hits' error

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/search_utils.py
+++ b/hysds_commons/search_utils.py
@@ -86,7 +86,8 @@ class SearchUtility(ABC):
             }
         }
         docs = self.es.search(**kwargs)
-        hits = docs["hits"]["hits"]
+
+        hits = docs.get("hits", {}).get("hits", [])
         if len(hits) == 0:
             if (type(ignore) is list and 404 in ignore) or (type(ignore) is int and ignore == 404):
                 not_found_doc = {


### PR DESCRIPTION
This PR fixes an issue that is caused when the `search_by_id` function does not find any results due to index_not_found. Under that scenario, the function should not expect the return JSON payload to be populated with "hits".

Therefore, the fix is to simply fallback to an empty dictionary/list when trying to get the number of results returned from the query.

As a test, once this change was made, a PCM container with this bug fix was built and the previously failed job ran successfully this go around:

![image](https://github.com/hysds/hysds_commons/assets/42812746/69466c96-577f-4ab4-91be-9f5d8fb3a795)
