### PR TITLE
hot-fix: fix failed unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
           name: Test
           command: |
             source $HOME/verdi/bin/activate
-            sudo yum -y update
-            sudo yum -y install gcc
+            #sudo yum -y update
+            #sudo yum -y install gcc
             cp $HOME/verdi/ops/hysds/configs/celery/celeryconfig.py.tmpl $HOME/verdi/ops/hysds/celeryconfig.py
             pip install -U pytest jsonschema
             pip install -e .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ jobs:
           name: Test
           command: |
             source $HOME/verdi/bin/activate
-            #sudo yum -y update
-            #sudo yum -y install gcc
             cp $HOME/verdi/ops/hysds/configs/celery/celeryconfig.py.tmpl $HOME/verdi/ops/hysds/celeryconfig.py
             pip install -U pytest jsonschema
             pip install -e .

--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"


### PR DESCRIPTION
This hot-fix resolves an issue where the weekly circleci test would fail due to the following issue:

```
Oracle Linux 8 Application Stream (x86_64)       91 MB/s |  64 MB     00:00    
Error: 
 Problem: package containerd.io-1.6.32-3.1.el8.x86_64 from @System conflicts with runc provided by runc-1:1.1.12-5.module+el8.10.0+90416+5b0f6a17.x86_64 from ol8_appstream
  - installed package containerd.io-1.6.32-3.1.el8.x86_64 obsoletes runc provided by runc-1:1.1.12-5.module+el8.10.0+90416+5b0f6a17.x86_64 from ol8_appstream
  - cannot install the best update candidate for package runc-1:1.1.12-4.module+el8.10.0+90412+9b361f34.x86_64
  - problem with installed package containerd.io-1.6.32-3.1.el8.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

Exited with code exit status 1
```

This appears to occur when the test is getting the latest yum updates. The resolution appears to be to simply remove trying to install these latest updates. Reason being is that we run these tests through `pge-base:latest` and that is already pulling in the latest and greatest packages. 
