### PR TITLE
HC-562: Pin numpy<2.0.0

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'elasticsearch>=7.0.0,<8.0.0',
+        'elasticsearch>=7.0.0',
         # Pin numpy due to ES incompatability: https://github.com/elastic/elasticsearch-py/issues/2646
         #'numpy<2.0.0',
         'opensearch-py>=2.3.0,<3.0.0',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'elasticsearch>=7.0.0,<7.14.0',
+        # Pin numpy. > 2.0.0 is incompatible with elasticsearch pin
+        'numpy<2.0.0',
         'opensearch-py>=2.3.0,<3.0.0',
         'requests>=2.7.0',
         'future>=0.17.1',

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'elasticsearch>=7.0.0,<7.14.0',
-        # Pin numpy since Cartopy (grq2) and ElasticSearch are not compatible with > 2.0
-        'numpy<2.0.0',
+        'elasticsearch>=7.0.0,<8.0.0',
+        # Pin numpy due to ES incompatability: https://github.com/elastic/elasticsearch-py/issues/2646
+        #'numpy<2.0.0',
         'opensearch-py>=2.3.0,<3.0.0',
         'requests>=2.7.0',
         'future>=0.17.1',

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'elasticsearch>=7.0.0',
+        'elasticsearch>=7.0.0,<7.14.0',
         # Pin numpy due to ES incompatability: https://github.com/elastic/elasticsearch-py/issues/2646
-        #'numpy<2.0.0',
+        'numpy<2.0.0',
         'opensearch-py>=2.3.0,<3.0.0',
         'requests>=2.7.0',
         'future>=0.17.1',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'elasticsearch>=7.0.0,<7.14.0',
-        # Pin numpy. > 2.0.0 is incompatible with elasticsearch pin
+        # Pin numpy since Cartopy (grq2) and ElasticSearch are not compatible with > 2.0
         'numpy<2.0.0',
         'opensearch-py>=2.3.0,<3.0.0',
         'requests>=2.7.0',


### PR DESCRIPTION
When testing the migration to using the conda-forge installer for conda installations with the following PR:

https://github.com/hysds/puppet-hysds_base/pull/22

ran through cluster provisioning and encountered this error:

```
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out: Traceback (most recent call last):
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/ops/grq2/scripts/install_base_es_template.py", line 13, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from grq2 import grq_es
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/ops/grq2/grq2/__init__.py", line 11, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from hysds.es_util import get_grq_es, get_mozart_es
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/ops/hysds/hysds/es_util.py", line 8, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from elasticsearch import RequestsHttpConnection as RequestsHttpConnectionES
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/elasticsearch/__init__.py", line 36, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from .client import Elasticsearch
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/elasticsearch/client/__init__.py", line 23, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from ..transport import Transport, TransportError
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/elasticsearch/transport.py", line 31, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     from .serializer import DEFAULT_SERIALIZERS, Deserializer, JSONSerializer
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/elasticsearch/serializer.py", line 50, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     np.float_,
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:   File "/export/home/hysdsops/conda/lib/python3.9/site-packages/numpy/__init__.py", line 397, in __getattr__
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out:     raise AttributeError(
module.common.aws_instance.mozart (remote-exec): [100.104.3.25] out: AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```
This is due to an incompatibility of NumPy 2.0 with ES 7: https://github.com/elastic/elasticsearch-py/issues/2646

Rather than try and do a wholesale upgrade to a higher version of ES (or completely remove it altogether), the simpler solution at this time is to pin NumPy to less than 2.0.

