### PR TITLE
HC-567: Added support for multi-architecture containers

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/job_utils.py
+++ b/hysds_commons/job_utils.py
@@ -445,6 +445,7 @@ def resolve_hysds_job(job_type=None, queue=None, priority=None, tags=None, param
         "job_type": f"job:{job_type}",
         "job_queue": queue,
         "container_image_url": container_spec.get("url", None),
+        "container_image_urls": container_spec.get("urls", None),
         "container_image_name": container_spec.get("id", None),
         "container_mappings": overlays,
         "runtime_options": runtime_options,


### PR DESCRIPTION
### Overview
This PR updates the job resolution logic in hysds_commons to propagate multi-architecture container metadata (`container_image_urls`) from Mozart's container specifications to HySDS job definitions. This enables workers to receive architecture-specific container URLs and automatically select the correct image for their platform.

### Changes

#### 🔧 Core Job Resolution ([hysds_commons/job_utils.py](cci:7://file:///Users/mcayanan/git/hysds_commons/hysds_commons/job_utils.py:0:0-0:0))
- **Updated [resolve_hysds_job()](cci:1://file:///Users/mcayanan/git/hysds_commons/hysds_commons/job_utils.py:359:0-491:14) function**:
  - Added `container_image_urls` field to job dictionary (line 445)
  - Reads `urls` field from container specification
  - Passes architecture mappings to workers via job metadata
  - Maintains backward compatibility with legacy `container_image_url` field

**Specific Change:**
```python
job = {
    "job_type": f"job:{job_type}",
    "job_queue": queue,
    "container_image_url": container_spec.get("url", None),
    "container_image_urls": container_spec.get("urls", None),  # NEW
    "container_image_name": container_spec.get("id", None),
    # ... rest of job fields
}
```

### Backward Compatibility ✅

- **Legacy `container_image_url` preserved**: Single URL field continues to be set
- **Optional `urls` field**: If not present in container spec, `container_image_urls` is `None`
- **No breaking changes**: Existing job resolution works identically
- **Graceful degradation**: Workers without multi-arch support ignore `container_image_urls`

### Data Flow

```
Container Metadata (Mozart Elasticsearch)
  {
    "id": "container-name:tag",
    "url": "s3://bucket/container-tag.tar.gz",
    "urls": "{\"x86_64\": \"...\", \"arm64\": \"...\"}"  ← Read from here
  }
  ↓
hysds_commons.resolve_hysds_job()
  ↓
Job Dictionary
  {
    "container_image_url": "s3://bucket/container-tag.tar.gz",
    "container_image_urls": "{\"x86_64\": \"...\", \"arm64\": \"...\"}"  ← Added here
  }
  ↓
Job Submission to Workers
  ↓
Worker Architecture Selection (hysds)
```

### Integration Requirements

This PR is part of a larger multi-architecture initiative. **Related PRs required:**

1. **hysds/mozart** - API endpoints updated to accept and store `urls` parameter in container metadata
2. **hysds/hysds** - Container loading logic updated to read `container_image_urls` and select architecture-specific URL
3. **hysds/container-builder** - Metadata registration script updated to upload and register both architecture tarballs

### Container Specification Schema

**Input (from Mozart Elasticsearch):**
```json
{
  "id": "container-name:tag",
  "url": "s3://bucket/container-name-tag.tar.gz",
  "urls": "{
    \"x86_64\": \"s3://bucket/container-name-tag.tar.gz\",
    \"amd64\": \"s3://bucket/container-name-tag.tar.gz\",
    \"arm64\": \"s3://bucket/container-name-tag-arm64.tar.gz\",
    \"aarch64\": \"s3://bucket/container-name-tag-arm64.tar.gz\"
  }",
  "version": "1.0.0",
  "digest": "sha256:..."
}
```

**Output (job dictionary):**
```python
{
  "job_type": "job:job-name:version",
  "job_queue": "queue-name",
  "container_image_url": "s3://bucket/container-name-tag.tar.gz",
  "container_image_urls": "{\"x86_64\": \"...\", \"arm64\": \"...\"}",  # NEW
  "container_image_name": "container-name:tag",
  # ... other job fields
}
```

### Testing

- ✅ Job resolution with multi-arch container (urls field present)
- ✅ Job resolution with legacy container (urls field absent)
- ✅ `container_image_urls` correctly propagated to job dict
- ✅ Backward compatibility with existing containers
- ✅ `None` handling when `urls` field is missing

### Example Scenarios

#### Scenario 1: Multi-Architecture Container
```python
# Container spec from Mozart
container_spec = {
    "id": "container-name:tag",
    "url": "s3://bucket/container-tag.tar.gz",
    "urls": '{"x86_64": "s3://bucket/container-tag.tar.gz", 
              "arm64": "s3://bucket/container-tag-arm64.tar.gz"}'
}

# Resolved job
job = resolve_hysds_job(...)
# job["container_image_url"] = "s3://bucket/container-tag.tar.gz"
# job["container_image_urls"] = '{"x86_64": "...", "arm64": "..."}'
```

#### Scenario 2: Legacy Single-Architecture Container
```python
# Container spec from Mozart (old format)
container_spec = {
    "id": "container-name:tag",
    "url": "s3://bucket/container-tag.tar.gz",
    # No "urls" field
}

# Resolved job
job = resolve_hysds_job(...)
# job["container_image_url"] = "s3://bucket/container-tag.tar.gz"
# job["container_image_urls"] = None  ← Gracefully handles missing field
```

### Migration Path

**For existing deployments:**
1. Deploy this PR to hysds_commons
2. Deploy related PRs to mozart, hysds, and container-builder
3. Update hysds_commons on Mozart: `cd /home/ops/verdi/ops/hysds_commons && git pull && pip install -e .`
4. Restart Mozart services
5. Existing containers continue to work without changes

**For new multi-arch containers:**
1. Register containers with both architectures using updated container-builder
2. Mozart stores `urls` field in container metadata
3. hysds_commons automatically propagates to job definitions
4. Workers receive and use architecture-specific URLs

### Error Handling

- **Missing `urls` field**: Returns `None` for `container_image_urls`, worker falls back to `container_image_url`
- **Invalid container spec**: Existing error handling unchanged
- **Malformed `urls` JSON**: Passed as-is to worker, worker handles parsing errors

### Verification

Check that jobs contain the new field:
```python
from hysds_commons import job_utils

job = job_utils.resolve_hysds_job(...)
print(job.get("container_image_urls"))
# Should print: '{"x86_64": "...", "arm64": "..."}'
```

---

**Dependencies:** Requires mozart, hysds, and container-builder PRs for full functionality  
**Breaking Changes:** None - fully backward compatible  
**Impact:** Low risk - adds optional field, maintains all existing behavior