### PR TITLE
HC-606: Updates to support OpenSearch 3.x

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'elasticsearch>=7.0.0,<7.14.0',
         # Pin numpy due to ES incompatability: https://github.com/elastic/elasticsearch-py/issues/2646
         'numpy<2.0.0',
-        'opensearch-py>=2.3.0,<3.0.0',
+        'opensearch-py>=2.3.0',
         'requests>=2.7.0',
         'future>=0.17.1',
         "jsonschema>=3.0.1",


### PR DESCRIPTION
This PR basically unpins the OpenSearch py requirement such that we can now use the latest and greatest in order to support the migration to OpenSearch 3.x