### PR TITLE
HC-633: Add SearchUtility.msearch() for multi search API support

### DIFF
--- a/hysds_commons/__init__.py
+++ b/hysds_commons/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __description__ = "Common HySDS Functions, Utilities, Etc."
 __url__ = "https://github.jpl.nasa.gov/hysds-org/hysds_commons"

--- a/hysds_commons/search_utils.py
+++ b/hysds_commons/search_utils.py
@@ -323,6 +323,31 @@ class SearchUtility(ABC):
         self._apply_closed_index_params(kwargs)
         return self.es.search(**kwargs)
 
+    def msearch(self, searches, **kwargs):
+        """
+        runs multiple searches in a single request through the multi search API and
+        returns the per-search responses in the same order as the given searches
+        https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.msearch
+        https://opensearch.org/docs/latest/api-reference/multi-search/
+            searches – list of (header, body) pairs, ex. ({"index": "grq"}, {"query": ...});
+                each header specifies the index/alias its search runs against and the body
+                is the search definition using the Query DSL; closed index handling params
+                are applied to each header the same way search() applies them to a single query
+            kwargs – additional params passed to the underlying msearch call
+                (ex. request_timeout, max_concurrent_searches)
+        """
+        if not searches:
+            return []
+        body = []
+        for header, search_body in searches:
+            header = dict(header)
+            for key, value in self.CLOSED_INDEX_PARAMS.items():
+                header.setdefault(key, value)
+            body.append(header)
+            body.append(search_body)
+        result = self.es.msearch(body=body, **kwargs)
+        return result["responses"]
+
     def get_count(self, **kwargs):
         """
         returning the count for a given query (warning: ES7 returns max of 10000)

--- a/test/test_search_utils.py
+++ b/test/test_search_utils.py
@@ -437,3 +437,76 @@ class TestClosedIndexParamsConstant:
         assert SearchUtility.CLOSED_INDEX_PARAMS["ignore_unavailable"] is True
         assert SearchUtility.CLOSED_INDEX_PARAMS["allow_no_indices"] is True
         assert SearchUtility.CLOSED_INDEX_PARAMS["expand_wildcards"] == "open"
+
+
+class TestMsearch:
+    """Tests for msearch() method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.utility = ConcreteSearchUtility()
+        self.utility.es.msearch.return_value = {
+            "responses": [
+                {"hits": {"total": {"value": 1}, "hits": [{"_id": "doc1"}]}},
+                {"hits": {"total": {"value": 0}, "hits": []}},
+            ]
+        }
+
+    def test_applies_closed_index_params_to_each_header(self):
+        """Should apply closed index params to every search header."""
+        searches = [
+            ({"index": "grq"}, {"query": {"match_all": {}}}),
+            ({"index": "job_status-*"}, {"query": {"term": {"_id": "foo"}}}),
+        ]
+        self.utility.msearch(searches)
+
+        body = self.utility.es.msearch.call_args.kwargs["body"]
+        assert len(body) == 4
+        for header in (body[0], body[2]):
+            assert header["ignore_unavailable"] is True
+            assert header["allow_no_indices"] is True
+            assert header["expand_wildcards"] == "open"
+        assert body[0]["index"] == "grq"
+        assert body[2]["index"] == "job_status-*"
+
+    def test_does_not_override_caller_params(self):
+        """Caller-specified header params should not be overridden."""
+        searches = [
+            ({"index": "grq", "expand_wildcards": "all"}, {"query": {"match_all": {}}})
+        ]
+        self.utility.msearch(searches)
+
+        body = self.utility.es.msearch.call_args.kwargs["body"]
+        assert body[0]["expand_wildcards"] == "all"
+
+    def test_does_not_mutate_caller_headers(self):
+        """Caller's header dicts should not be modified in place."""
+        header = {"index": "grq"}
+        self.utility.msearch([(header, {"query": {"match_all": {}}})])
+
+        assert header == {"index": "grq"}
+
+    def test_returns_responses_in_request_order(self):
+        """Responses should be returned in the same order as the searches."""
+        searches = [
+            ({"index": "grq"}, {"query": {"term": {"_id": "a"}}}),
+            ({"index": "grq"}, {"query": {"term": {"_id": "b"}}}),
+        ]
+        responses = self.utility.msearch(searches)
+
+        assert len(responses) == 2
+        assert responses[0]["hits"]["total"]["value"] == 1
+        assert responses[1]["hits"]["total"]["value"] == 0
+
+    def test_empty_searches_returns_empty_list(self):
+        """Empty searches list should short-circuit without calling ES."""
+        assert self.utility.msearch([]) == []
+        self.utility.es.msearch.assert_not_called()
+
+    def test_kwargs_passed_through(self):
+        """Additional kwargs should be passed to the underlying msearch call."""
+        self.utility.msearch(
+            [({"index": "grq"}, {"query": {"match_all": {}}})], request_timeout=30
+        )
+
+        assert self.utility.es.msearch.call_args.kwargs["request_timeout"] == 30


### PR DESCRIPTION
## Purpose
Add `SearchUtility.msearch()` so callers can run multiple searches in a single request via the Multi-Search API. Used by hysds user-rules evaluation (HC-633) to check all trigger rules in one round trip instead of one search per rule.

https://hysds-core.atlassian.net/browse/HC-633

## Before vs after

| | Before (caller looped) | After (`msearch`) |
|---|---|---|
| Requests | one `search` per rule (R round trips) | **one** `_msearch` request |
| Closed-index params | per `search` call | applied per search header |
| Result | R responses | R responses, in request order |
| One bad item | — | surfaced as a wrapped `RequestError` so the caller can isolate it |

**Before — one search per rule**

```mermaid
flowchart TB
    b1["rule 1"] --> s1["search"] --> r1["response 1"]
    b2["rule 2"] --> s2["search"] --> r2["response 2"]
    b3["rule N"] --> s3["search"] --> r3["response N"]
```

**After — SearchUtility.msearch()**

```mermaid
flowchart TB
    a1["header,body pairs x N<br/>closed-index params per header"] --> m["one _msearch request"]
    m --> o["N responses in request order"]
```

## Changes
- `SearchUtility.msearch(searches, **kwargs)`: takes a list of `(header, body)` pairs, applies the same closed-index-handling params as `search()` to each search header (caller-specified values win), submits one `_msearch` request, and returns the per-search responses in request order. Empty input short-circuits without calling ES.
- Unit tests covering closed-index param application, caller overrides, non-mutation of caller headers, response ordering, empty input, and kwargs passthrough.

## Testing & Validation
- **Unit (`test/test_search_utils.py`):** 45 passed (39 existing + 6 new).
- **End-to-end via consumer (hysds/hysds#219) on an OPERA DISP-S1 dev-e2e cluster, real OpenSearch:** hundreds of multi-search requests, each batching all enabled trigger rules for a single evaluation with closed-index params applied per header — **0 errored** across the campaign.
- **Error path:** a search item carrying a valid-JSON/unparseable-DSL query (which the client surfaces as a wrapped `RequestError`) is propagated correctly to the caller, so the consumer can fall back to per-rule searches and isolate the offending item rather than losing the whole batch. Verified live against real OpenSearch.

## Test artifacts

<details>
<summary>Error-path propagation — a registered bad-DSL rule, isolated per-item (real worker)</summary>

A valid-JSON / unparseable-DSL rule was registered as an enabled trigger rule and a `user_rules_dataset` evaluation job submitted; `msearch()` surfaced the wrapped `RequestError` to the caller, which fell back to per-rule searches and isolated the offending item:

```
ERROR  msearch rejected at request parse time (RequestError(400, x_content_parse_exception,
       unknown query [termzz]...)); falling back to per-rule searches
ERROR  Rule 'hc633-fallback-test-badrule' query failed: {"reason": "...RequestError(400, ...)"}
INFO   Evaluated 27 rules: matched=[] errored=['hc633-fallback-test-badrule']
```

The bad item is isolated and the batch is not lost (the 26 sibling rules still evaluated).
</details>

## Cross-project validation

This change lands in the shared HySDS framework and is consumed by multiple SDS projects; each should validate it against its own pipeline before merge. Validation guidance for the NISAR/SWOT teams is in the consumer PR hysds/hysds#219 — validating the trigger cascade there exercises `msearch()` here too.

- [x] **OPERA** — validated end-to-end via the consumer (hysds/hysds#219) on a DISP-S1 dev-e2e cluster (see **Testing & Validation** and **Test artifacts** above).
- [ ] **NISAR** — _pending._
- [ ] **SWOT** — _pending._

<details>
<summary>NISAR — test + validation (placeholder)</summary>

_To be added by the NISAR team._
</details>

<details>
<summary>SWOT — test + validation (placeholder)</summary>

_To be added by the SWOT team._
</details>

## Notes
- Additive only; no behavior change to existing methods.
- Version bumped 2.3.0 → 2.4.0 so consumers can pin the msearch-capable release (hysds/hysds#219 requires `hysds_commons>=2.4.0`).
- Companion PR: hysds/hysds#219 (user-rules evaluation consumer).
- Clean cherry-pick to the v6.1.2-era line is staged on branch `v2.1.x` (cut from tag v2.1.1) for venues on hysds-framework v6.1.2 that need this before v6.3.3.

