### PR TITLE
HC-645: Use create_pit/delete_pit so deep pagination works on opensearch-py 3.x

### DIFF
--- a/hysds_commons/opensearch_utils.py
+++ b/hysds_commons/opensearch_utils.py
@@ -32,8 +32,8 @@ class OpenSearchUtility(SearchUtility):
         using the PIT (point-in-time) + search_after API to do deep pagination
           - https://opensearch.org/docs/latest/search-plugins/point-in-time/
           - https://opensearch.org/docs/latest/search-plugins/point-in-time/#pagination-with-pit-and-search_after
-          - https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html#opensearchpy.OpenSearch.create_point_in_time
-          - https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html#opensearchpy.OpenSearch.delete_point_in_time
+          - https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html#opensearchpy.OpenSearch.create_pit
+          - https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html#opensearchpy.OpenSearch.delete_pit
         :param kwargs: please see the docstrings for the "search" method below
             * index is required when using the search_after API
         :return: List[any]
@@ -52,7 +52,17 @@ class OpenSearchUtility(SearchUtility):
             if key != "allow_no_indices":  # PIT APIs don't accept this param
                 pit_params[key] = kwargs.pop(key, default_value)
         
-        pit = self.es.create_point_in_time(index=index, keep_alive=keep_alive, **pit_params)
+        # opensearch-py 3.x removed create_point_in_time/delete_point_in_time in
+        # favour of create_pit/delete_pit (present since 2.4.1). create_pit takes
+        # no direct query-param kwargs -- keep_alive and the closed-index params
+        # must ride in `params`, with booleans stringified for the query string.
+        pit = self.es.create_pit(
+            index=index,
+            params={
+                "keep_alive": keep_alive,
+                **{k: (str(v).lower() if isinstance(v, bool) else v) for k, v in pit_params.items()},
+            },
+        )
         pit_id = pit["pit_id"]
 
         # Once the PIT is open, strip any remaining indicesOptions from kwargs — OpenSearch/ES
@@ -83,5 +93,5 @@ class OpenSearchUtility(SearchUtility):
             body["search_after"] = last_record["sort"]
             res = self.es.search(body=body, **kwargs)
 
-        self.es.delete_point_in_time(body={"pit_id": [pit_id]})
+        self.es.delete_pit(body={"pit_id": [pit_id]})
         return records

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,10 @@ setup(
         'elasticsearch>=7.0.0,<7.14.0',
         # Pin numpy due to ES incompatability: https://github.com/elastic/elasticsearch-py/issues/2646
         'numpy<2.0.0',
-        'opensearch-py>=2.3.0',
+        # create_pit/delete_pit (used by OpenSearchUtility._pit) first appear in a
+        # release that also installs on Python 3.12 at 2.4.1; 2.3.x only has the
+        # spellings that opensearch-py 3.0 removed.
+        'opensearch-py>=2.4.1',
         'requests>=2.7.0',
         'future>=0.17.1',
         "jsonschema>=3.0.1",

--- a/test/test_search_utils.py
+++ b/test/test_search_utils.py
@@ -345,33 +345,39 @@ class TestOpenSearchPitMethod:
     def setup_method(self):
         """Set up test fixtures."""
         self.utility = MockOpenSearchUtility()
-        self.utility.es.create_point_in_time.return_value = {
+        self.utility.es.create_pit.return_value = {
             "pit_id": "opensearch_pit_id_123"
         }
         self.utility.es.search.return_value = {
             "hits": {"total": {"value": 0}, "hits": []}
         }
-        self.utility.es.delete_point_in_time.return_value = {"succeeded": True}
+        self.utility.es.delete_pit.return_value = {"succeeded": True}
 
     def test_create_pit_applies_closed_index_params(self):
-        """create_point_in_time() should receive ignore_unavailable and expand_wildcards."""
+        """create_pit() should receive ignore_unavailable and expand_wildcards via params.
+
+        opensearch-py's create_pit takes no direct query-param kwargs, so these ride
+        in `params` and booleans are stringified for the query string.
+        """
         self.utility._pit(index="grq_v1.0_product-*", body={"query": {"match_all": {}}})
-        call_kwargs = self.utility.es.create_point_in_time.call_args[1]
-        assert call_kwargs["ignore_unavailable"] is True
-        assert call_kwargs["expand_wildcards"] == "open"
+        call_params = self.utility.es.create_pit.call_args.kwargs["params"]
+        assert call_params["ignore_unavailable"] == "true"
+        assert call_params["expand_wildcards"] == "open"
+        assert call_params["keep_alive"] == "2m"
 
     def test_create_pit_does_not_pass_allow_no_indices(self):
         """PIT open APIs don't accept allow_no_indices -- must not be passed."""
         self.utility._pit(index="grq", body={"query": {"match_all": {}}})
-        call_kwargs = self.utility.es.create_point_in_time.call_args[1]
+        call_kwargs = self.utility.es.create_pit.call_args.kwargs
         assert "allow_no_indices" not in call_kwargs
+        assert "allow_no_indices" not in call_kwargs["params"]
 
     def test_create_pit_applies_params_for_alias(self):
-        """create_point_in_time() should apply params for aliases (no wildcard in name)."""
+        """create_pit() should apply params for aliases (no wildcard in name)."""
         self.utility._pit(index="grq", body={"query": {"match_all": {}}})
-        call_kwargs = self.utility.es.create_point_in_time.call_args[1]
-        assert call_kwargs["ignore_unavailable"] is True
-        assert call_kwargs["expand_wildcards"] == "open"
+        call_params = self.utility.es.create_pit.call_args.kwargs["params"]
+        assert call_params["ignore_unavailable"] == "true"
+        assert call_params["expand_wildcards"] == "open"
 
     def test_create_pit_does_not_override_caller_params(self):
         """Caller-specified closed-index params should not be overridden."""
@@ -381,9 +387,9 @@ class TestOpenSearchPitMethod:
             ignore_unavailable=False,
             expand_wildcards="all",
         )
-        call_kwargs = self.utility.es.create_point_in_time.call_args[1]
-        assert call_kwargs["ignore_unavailable"] is False
-        assert call_kwargs["expand_wildcards"] == "all"
+        call_params = self.utility.es.create_pit.call_args.kwargs["params"]
+        assert call_params["ignore_unavailable"] == "false"
+        assert call_params["expand_wildcards"] == "all"
 
     def test_pit_search_does_not_pass_indices_options(self):
         """_search calls with PIT must NOT include indicesOptions."""
@@ -413,7 +419,7 @@ class TestOpenSearchPitMethod:
         assert records[0]["_id"] == "1"
         assert records[1]["_id"] == "2"
         # Verify PIT was cleaned up
-        self.utility.es.delete_point_in_time.assert_called_once_with(
+        self.utility.es.delete_pit.assert_called_once_with(
             body={"pit_id": ["opensearch_pit_id_123"]}
         )
 
@@ -421,6 +427,43 @@ class TestOpenSearchPitMethod:
         """_pit() should raise RuntimeError when no index is provided."""
         with pytest.raises(RuntimeError, match="must specify a index/alias"):
             self.utility._pit(body={"query": {"match_all": {}}})
+
+
+class TestOpenSearchClientSurface:
+    """Bind the mocked PIT contract to the real installed opensearch-py client.
+
+    The tests above mock self.es, so they pass regardless of which client version
+    is installed -- which is exactly how an upstream client API removal shipped
+    undetected: opensearch-py 3.0 dropped create_point_in_time/delete_point_in_time
+    while OpenSearchUtility._pit() still called them. These assertions fail loudly
+    in CI if the methods _pit() depends on are dropped or reshaped again.
+    """
+
+    def test_pit_methods_exist_on_real_client(self):
+        """_pit() calls these directly -- they must exist on the installed client."""
+        from opensearchpy import OpenSearch
+
+        assert hasattr(OpenSearch, "create_pit")
+        assert hasattr(OpenSearch, "delete_pit")
+
+    def test_create_pit_accepts_index_and_params(self):
+        """_pit() passes index= and params= as keywords."""
+        import inspect
+
+        from opensearchpy import OpenSearch
+
+        sig = inspect.signature(OpenSearch.create_pit)
+        assert "index" in sig.parameters
+        assert "params" in sig.parameters
+
+    def test_delete_pit_accepts_body(self):
+        """_pit() cleans up with delete_pit(body=...)."""
+        import inspect
+
+        from opensearchpy import OpenSearch
+
+        sig = inspect.signature(OpenSearch.delete_pit)
+        assert "body" in sig.parameters
 
 
 class TestClosedIndexParamsConstant:


### PR DESCRIPTION
## Summary

`OpenSearchUtility._pit()` called `create_point_in_time()` / `delete_point_in_time()`. **opensearch-py 3.0 removed both** in favour of `create_pit()`/`delete_pit()`, and HC-606 raised this package's ceiling from `opensearch-py>=2.3.0,<3.0.0` to an unbounded `>=2.3.0` without touching the call site.

The v6.4.2 venv bundles ship **opensearch_py 3.2.0** — read from the `.dist-info` entries in `hysds-mozart_venv-v6.4.2.tar.gz` and `hysds-grq_venv-v6.4.2.tar.gz` — so on every v6.4.2 deployment `SearchUtility.query()` raises `AttributeError` once a result set reaches the 10,000-hit `page_limit` and switches to the PIT path. Below that threshold `from_`/`size` paging is unaffected, which is why this survived integration testing on small datasets.

Fixes [HC-645](https://hysds-core.atlassian.net/browse/HC-645).

## Why a rename alone is not enough

Two independent reasons, both measured:

**1. `create_pit` takes no direct query-param kwargs.** `keep_alive` and the HC-600 closed-index params must ride in `params`, with booleans stringified for the query string. Passing them as kwargs raises `TypeError: OpenSearch.create_pit() got an unexpected keyword argument 'ignore_unavailable'` on 3.x.

**2. `create_pit` does not exist at the declared floor.** opensearch-py 2.3.0 has only the removed spellings, so a bare rename would break the floor:

| opensearch-py | `create_pit`/`delete_pit` | installs on py3.12 |
|---|---|---|
| 2.3.0 (old floor) | **absent** | yes |
| 2.4.0 | — | **no** (and this package requires `python>=3.12`) |
| **2.4.1** | **present** | **yes** ← new floor |
| 2.8.0 | present (both spellings) | yes |
| 3.2.0 | present (new only) | yes |

## Verification

Live single-node servers with the **security plugin enabled** (`OpenSearchUtility` hardcodes `use_ssl=True` and reads `~/.netrc-os`), driving `query()` over 10,500 documents through the real `OpenSearchUtility`:

| client | server | result |
|---|---|---|
| opensearch-py 2.8.0 | OpenSearch 2.9.0 | **10500/10500** |
| opensearch-py 2.8.0 | OpenSearch 3.6.0 | **10500/10500** |
| opensearch-py 3.2.0 | OpenSearch 2.9.0 | **10500/10500** |
| opensearch-py 3.2.0 | OpenSearch 3.6.0 | **10500/10500** |

`create_pit`'s response carries `pit_id` on every pairing (`_shards`, `creation_time`, `pit_id`), so **one unconditional code path covers both client majors and both server majors** — no `hasattr` dispatch needed.

Unit suite: `test/test_search_utils.py` is 48/48 green on opensearch-py **2.4.1** (the new floor), **2.8.0**, and **3.2.0**.

## Tests

`TestOpenSearchPitMethod` asserted the old spellings and direct kwargs, so it actively contradicted the fix. Updated to assert on `params` with stringified booleans (`"true"`/`"false"`).

`TestPitMethod` is **deliberately untouched** — it covers the Elasticsearch-flavoured `SearchUtility._pit()`, which uses `open_point_in_time`/`close_point_in_time`. Both are present on the pinned `elasticsearch==7.13.4` client and are unaffected by the opensearch-py change.

**`TestOpenSearchClientSurface` is new**, and it is the part worth reviewing. The existing PIT tests mock `self.es` with a `MagicMock`, so `create_point_in_time` resolved regardless of which client was installed — that is precisely how this API removal reached a release undetected. The new class binds the mocked contract to the real installed opensearch-py. Confirmed to do its job: it **fails on 2.3.0** (3 failures) and passes on 2.4.1 / 2.8.0 / 3.2.0.

## Notes for the reviewer

- `__version__` is deliberately left at `2.4.0` — the release process owns the bump (expected `v2.4.1` as part of HySDS **v6.4.3**).
- **The `v7.0.x` tags carry the same bug.** `v7.0.0` / `v7.0.1` / `v7.0.2rc1` fork from `develop` at `e476695` and still call both removed methods, but there is no remote branch for that line, so it cannot be PR'd here. Note that its dependency floor lives in `pyproject.toml`, not `setup.py`. Flagged on HC-645 for a port.
- Scope check: a sweep of `hysds`, `lightweight-jobs`, `mozart`, `grq2`, `pele`, `sdscli`, `osaka`, `chimera` and `prov_es` found **zero** references to the removed symbols. `hysds_commons` is the only repo needing a code change; everything else inherits the fix.
- A full `dir()` diff of the client between 2.8.0 and 3.2.0 across the `OpenSearch`, `indices`, `cat`, `snapshot` and `cluster` namespaces shows exactly three removals — `create_point_in_time`, `delete_point_in_time`, `list_all_point_in_time`. PIT is the entire blast radius; nothing else needs auditing.
- Pre-existing and unrelated: `test/utils/test_linux_utils.py::test_get_gateway_ip` fails on macOS (reads `/proc/1/cgroup`); it fails identically on clean `develop`. Green in CI's Linux container.


[HC-645]: https://hysds-core.atlassian.net/browse/HC-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ